### PR TITLE
Reduce default inference cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ print(segmentations)
 # ['we need a national park', 'ice cold']
 ```
 
+The default search uses `topk=5` and `steps=5` for interactive performance.
+For a wider search, use `ws.segment(inputs, topk=20, steps=13)`. Inference
+batches default to 64 candidates and can be configured when constructing the
+segmenter.
+
 ### Using Language-Specific Models
 
 ```python

--- a/src/hashformers/beamsearch/algorithm.py
+++ b/src/hashformers/beamsearch/algorithm.py
@@ -14,7 +14,7 @@ class Beamsearch(ModelLM):
             model_name_or_path="gpt2", 
             model_type="gpt2", 
             device='cuda', 
-            gpu_batch_size=1000):
+            gpu_batch_size=64):
         """
         Initializes the Beamsearch class.
 
@@ -22,7 +22,7 @@ class Beamsearch(ModelLM):
             model_name_or_path (str): Name of the model or path to the model to be loaded. Default is "gpt2".
             model_type (str): Type of the model. Default is "gpt2".
             device (str): Device to be used for computation. Default is 'cuda'.
-            gpu_batch_size (int): Size of the batch to be processed on the GPU. Default is 1000.
+            gpu_batch_size (int): Size of the batch to be processed on the GPU. Default is 64.
         """
         super().__init__(
             model_name_or_path=model_name_or_path, 
@@ -61,17 +61,15 @@ class Beamsearch(ModelLM):
         Returns:
             dict: Updated probability dictionary.
         """
-        for item in tree:
-            current_batch = []
-            for word in item:
-                if word in prob_dict:
-                    continue
-                else:
-                    current_batch.append(word)
-            if current_batch:
-                current_batch_probs = self.model.get_probs(current_batch)
-            for idx, word in enumerate(current_batch):
-                prob_dict[word] = current_batch_probs[idx]
+        current_batch = list(dict.fromkeys(
+            word
+            for item in tree
+            for word in item
+            if word not in prob_dict
+        ))
+        if current_batch:
+            current_batch_probs = self.model.get_probs(current_batch)
+            prob_dict.update(zip(current_batch, current_batch_probs))
         return prob_dict
 
     def reshape_tree(self, tree, measure):
@@ -123,14 +121,14 @@ class Beamsearch(ModelLM):
             output.extend(trimmed_group)
         return output
 
-    def run(self, dataset, topk=20, steps=13):
+    def run(self, dataset, topk=5, steps=5):
         """
         Runs the beamsearch algorithm on the provided dataset.
 
         Args:
             dataset (List[str]): List of initial candidate strings.
-            topk (int): Number of top candidates to be retained in each step. Default is 20.
-            steps (int): Number of steps to run the algorithm. Default is 13.
+            topk (int): Number of top candidates to be retained in each step. Default is 5.
+            steps (int): Number of steps to run the algorithm. Default is 5.
         
         Returns:
             ProbabilityDictionary: Dictionary of final probabilities of the candidates.

--- a/src/hashformers/beamsearch/reranker.py
+++ b/src/hashformers/beamsearch/reranker.py
@@ -15,7 +15,7 @@ class Reranker(ModelLM):
     Args:
         model_name_or_path (str, optional): The name or path of the pre-trained model. Default is "bert-base-cased".
         model_type (str, optional): The type of the model to use. Default is "bert".
-        gpu_batch_size (int, optional): The batch size to use when performing computations on the GPU. Default is 1000.
+        gpu_batch_size (int, optional): The batch size to use when performing computations on the GPU. Default is 64.
         gpu_id (int, optional): The ID of the GPU to use. Default is 0.
         device (str, optional): The device on which to run the computations. Default is "cuda".
 
@@ -24,7 +24,7 @@ class Reranker(ModelLM):
         self,
         model_name_or_path="bert-base-cased",
         model_type="bert",
-        gpu_batch_size=1000,
+        gpu_batch_size=64,
         gpu_id=0,
         device="cuda"
     ):

--- a/src/hashformers/segmenter/auto.py
+++ b/src/hashformers/segmenter/auto.py
@@ -12,8 +12,8 @@ class TransformerWordSegmenter(BaseWordSegmenter):
         segmenter_model_name_or_path = "gpt2",
         segmenter_model_type = "gpt2",
         segmenter_device = "cuda",
-        segmenter_gpu_batch_size = 1000,
-        reranker_gpu_batch_size = 1000,
+        segmenter_gpu_batch_size = 64,
+        reranker_gpu_batch_size = 64,
         reranker_model_name_or_path = None,
         reranker_model_type = "bert",
         reranker_device = "cuda"
@@ -27,8 +27,8 @@ class TransformerWordSegmenter(BaseWordSegmenter):
             segmenter_model_name_or_path (str, optional): GPT-2 that will be fetched from the Hugging Face Model Hub. Defaults to "gpt2".
             segmenter_model_type (str, optional): Transformer decoder model type. Defaults to "gpt2".
             segmenter_device (str, optional): Device. Defaults to "cuda".
-            segmenter_gpu_batch_size (int, optional): Segmenter GPU batch size. Defaults to 1.
-            reranker_gpu_batch_size (int, optional): Reranker GPU split size. Defaults to 2000.
+            segmenter_gpu_batch_size (int, optional): Segmenter GPU batch size. Defaults to 64.
+            reranker_gpu_batch_size (int, optional): Reranker GPU split size. Defaults to 64.
             reranker_model_name_or_path (str, optional): BERT model that will be fetched from the Hugging Face Model Hub. It is possible to turn off the reranker by passing a None or False value to this argument. Defaults to "bert-base-uncased".
             reranker_model_type (str, optional): Transformer encoder model type. Defaults to "bert".
         """
@@ -60,8 +60,8 @@ class TransformerWordSegmenter(BaseWordSegmenter):
     def segment(
             self,
             word_list,
-            topk: int = 20,
-            steps: int = 13,
+            topk: int = 5,
+            steps: int = 5,
             alpha: float = 0.222,
             beta: float = 0.111,
             use_reranker: bool = True,

--- a/src/hashformers/spacy/__init__.py
+++ b/src/hashformers/spacy/__init__.py
@@ -46,7 +46,7 @@ class HashformersComponent:
         name: str,
         model: str = "distilgpt2",
         device: str = "cuda",
-        gpu_batch_size: int = 1000
+        gpu_batch_size: int = 64
     ):
         """
         Initialize the HashformersComponent.
@@ -59,7 +59,7 @@ class HashformersComponent:
             device: Device to run the model on ("cuda" or "cpu").
                 Defaults to "cuda".
             gpu_batch_size: Batch size for GPU processing.
-                Defaults to 1000.
+                Defaults to 64.
         """
         self.nlp = nlp
         self.name = name
@@ -106,7 +106,7 @@ if SPACY_AVAILABLE:
         default_config={
             "model": "distilgpt2",
             "device": "cuda",
-            "gpu_batch_size": 1000
+            "gpu_batch_size": 64
         }
     )
     def create_hashformers_component(

--- a/tests/test_performance_defaults.py
+++ b/tests/test_performance_defaults.py
@@ -1,0 +1,56 @@
+import inspect
+
+from hashformers.beamsearch.algorithm import Beamsearch
+from hashformers.beamsearch.reranker import Reranker
+from hashformers.segmenter.auto import TransformerWordSegmenter
+
+
+class RecordingModel:
+    def __init__(self):
+        self.calls = []
+
+    def get_probs(self, candidates):
+        self.calls.append(candidates)
+        return list(range(len(candidates)))
+
+
+def test_candidates_are_deduplicated_before_scoring():
+    beamsearch = object.__new__(Beamsearch)
+    beamsearch.model = RecordingModel()
+    probabilities = {"already scored": 9}
+
+    result = beamsearch.update_probabilities(
+        [["first", "duplicate", "already scored"], ["duplicate", "second"]],
+        probabilities,
+    )
+
+    assert beamsearch.model.calls == [["first", "duplicate", "second"]]
+    assert result == {
+        "already scored": 9,
+        "first": 0,
+        "duplicate": 1,
+        "second": 2,
+    }
+
+
+def test_empty_pending_batch_does_not_call_scorer():
+    beamsearch = object.__new__(Beamsearch)
+    beamsearch.model = RecordingModel()
+
+    beamsearch.update_probabilities([["cached", "cached"]], {"cached": 1})
+
+    assert beamsearch.model.calls == []
+
+
+def test_performance_defaults():
+    beamsearch_init = inspect.signature(Beamsearch.__init__).parameters
+    reranker_init = inspect.signature(Reranker.__init__).parameters
+    segmenter_init = inspect.signature(TransformerWordSegmenter.__init__).parameters
+    segment = inspect.signature(TransformerWordSegmenter.segment).parameters
+
+    assert beamsearch_init["gpu_batch_size"].default == 64
+    assert reranker_init["gpu_batch_size"].default == 64
+    assert segmenter_init["segmenter_gpu_batch_size"].default == 64
+    assert segmenter_init["reranker_gpu_batch_size"].default == 64
+    assert segment["topk"].default == 5
+    assert segment["steps"].default == 5


### PR DESCRIPTION
## Summary

- reduce segmenter and reranker batch defaults from 1,000 to 64
- deduplicate pending candidates before model scoring
- reduce default beam search from `topk=20, steps=13` to `topk=5, steps=5`
- retain the previous search settings as explicit configuration
- document the performance/quality tradeoff

## Impact

This bounds batch-dependent GPU memory, avoids redundant scoring, and substantially reduces the default search budget for interactive use.

## Validation

- focused candidate deduplication and cache-skipping checks
- Python syntax compilation
- `git diff --check`

The full pytest suite was not run locally because the environment lacks its runtime and test dependencies.

Closes #58