### PR TITLE
Fix reranker score ordering

### DIFF
--- a/src/hashformers/beamsearch/minicons_lm.py
+++ b/src/hashformers/beamsearch/minicons_lm.py
@@ -4,6 +4,13 @@ import warnings
 import math
 
 class MiniconsLM(object):
+    """Score candidate sequences using lower-is-better costs.
+
+    Attributes:
+        scorer: The minicons scorer used for the selected model type.
+        gpu_batch_size: Maximum number of candidates scored in one batch.
+        model_type: Name of the configured minicons scorer type.
+    """
 
     def __init__(self, model_name_or_path, device='cuda', gpu_batch_size=20, model_type='IncrementalLMScorer'):
         self.scorer = getattr(scorer, model_type)(model_name_or_path, device)
@@ -29,9 +36,10 @@ class MiniconsLM(object):
         if self.model_type == 'IncrementalLMScorer':
             return self.incremental_sequence_score(batch)
         elif self.model_type == 'MaskedLMScorer':
-            return self.scorer.sequence_score(batch, reduction = lambda x: x.sum(0).item())
+            return self.scorer.sequence_score(batch, reduction = lambda x: -x.sum(0).item())
         elif self.model_type == 'Seq2SeqScorer':
-            return self.scorer.sequence_score(batch, source_format = 'blank')
+            scores = self.scorer.sequence_score(batch, source_format = 'blank')
+            return [-score for score in scores]
         else:
-            warnings.warn(f"Model type {self.model_type} not implemented. Assuming reduction = lambda x: x.sum(0).item()")
-            return self.scorer.sequence_score(batch, reduction = lambda x: x.sum(0).item())
+            warnings.warn(f"Model type {self.model_type} not implemented. Assuming negative summed log probability.")
+            return self.scorer.sequence_score(batch, reduction = lambda x: -x.sum(0).item())

--- a/tests/test_score_ordering.py
+++ b/tests/test_score_ordering.py
@@ -1,0 +1,47 @@
+from hashformers.beamsearch.minicons_lm import MiniconsLM
+
+
+class Scalar:
+    def __init__(self, value):
+        self.value = value
+
+    def item(self):
+        return self.value
+
+
+class TokenScores:
+    def __init__(self, total):
+        self.total = total
+
+    def sum(self, _dimension):
+        return Scalar(self.total)
+
+
+class MaskedScorer:
+    def sequence_score(self, _batch, reduction):
+        return [reduction(TokenScores(-5)), reduction(TokenScores(-20))]
+
+
+class Seq2SeqScorer:
+    def sequence_score(self, _batch, source_format):
+        assert source_format == "blank"
+        return [-5, -20]
+
+
+def build_lm(model_type, scorer):
+    lm = object.__new__(MiniconsLM)
+    lm.model_type = model_type
+    lm.scorer = scorer
+    return lm
+
+
+def test_masked_scores_are_lower_for_more_probable_candidates():
+    lm = build_lm("MaskedLMScorer", MaskedScorer())
+
+    assert lm.get_batch_scores(["more probable", "less probable"]) == [5, 20]
+
+
+def test_seq2seq_scores_are_lower_for_more_probable_candidates():
+    lm = build_lm("Seq2SeqScorer", Seq2SeqScorer())
+
+    assert lm.get_batch_scores(["more probable", "less probable"]) == [5, 20]


### PR DESCRIPTION
## Summary

- document Hashformers' lower-is-better score convention
- convert masked-LM summed log probabilities into positive costs
- invert seq2seq log-probability scores before ranking
- apply the same convention to the generic scorer fallback
- add controlled score-ordering tests

## Root cause

Hashformers sorts scores in ascending order, while masked and seq2seq scorers returned raw log probabilities where larger values are better. This could cause the reranker to prefer less probable candidates.

## Validation

- controlled checks confirm a log probability of `-5` receives a better cost than `-20`
- Python syntax compilation
- `git diff --check`

The full pytest suite was not run locally because the environment lacks its runtime and test dependencies.

Closes #59