### PR TITLE
Honor reranker device configuration

### DIFF
--- a/src/hashformers/beamsearch/bert_lm.py
+++ b/src/hashformers/beamsearch/bert_lm.py
@@ -8,15 +8,16 @@ class BertLM(MiniconsLM):
     Args:
         model_name_or_path (str): Identifier for the model to be loaded, which can be a model 
             name or the path to the directory where the model is stored.
-        gpu_batch_size (int, optional): The size of the batch to be processed on the GPU. 
+        gpu_batch_size (int, optional): The size of the batch to be processed on the GPU.
             Defaults to 1.
         gpu_id (int, optional): Identifier of the GPU device to be used. Defaults to 0.
+        device (str, optional): Device on which to run the model. Defaults to "cuda".
 
     """
-    def __init__(self, model_name_or_path, gpu_batch_size=1, gpu_id=0):
+    def __init__(self, model_name_or_path, gpu_batch_size=1, gpu_id=0, device='cuda'):
         super().__init__(
             model_name_or_path=model_name_or_path,
-            device='cuda',
+            device=device,
             gpu_batch_size=gpu_batch_size,
             model_type='MaskedLMScorer'
         )

--- a/src/hashformers/beamsearch/model_lm.py
+++ b/src/hashformers/beamsearch/model_lm.py
@@ -28,7 +28,12 @@ class ModelLM(object):
         elif model_type == 'gpt2':
             self.model = GPT2LM(model_name_or_path, device=device, gpu_batch_size=gpu_batch_size)
         elif model_type == 'bert':
-            self.model = BertLM(model_name_or_path, gpu_batch_size=gpu_batch_size, gpu_id=gpu_id)
+            self.model = BertLM(
+                model_name_or_path,
+                gpu_batch_size=gpu_batch_size,
+                gpu_id=gpu_id,
+                device=device,
+            )
         elif model_type == 'seq2seq':
             self.model = MiniconsLM(model_name_or_path, device=device, gpu_batch_size=gpu_batch_size, model_type='Seq2SeqScorer')
         elif model_type == 'masked':

--- a/tests/test_reranker_device.py
+++ b/tests/test_reranker_device.py
@@ -1,0 +1,59 @@
+from hashformers.beamsearch import model_lm
+from hashformers.beamsearch import bert_lm
+
+
+class RecordingBertLM:
+    calls = []
+
+    def __init__(self, model_name_or_path, gpu_batch_size, gpu_id, device):
+        self.calls.append({
+            "model_name_or_path": model_name_or_path,
+            "gpu_batch_size": gpu_batch_size,
+            "gpu_id": gpu_id,
+            "device": device,
+        })
+
+
+def test_bert_model_receives_requested_device(monkeypatch):
+    monkeypatch.setattr(model_lm, "BertLM", RecordingBertLM)
+
+    model_lm.ModelLM(
+        model_name_or_path="bert-model",
+        model_type="bert",
+        device="cpu",
+        gpu_batch_size=8,
+        gpu_id=2,
+    )
+
+    assert RecordingBertLM.calls[-1] == {
+        "model_name_or_path": "bert-model",
+        "gpu_batch_size": 8,
+        "gpu_id": 2,
+        "device": "cpu",
+    }
+
+
+def test_explicit_cuda_device_is_preserved(monkeypatch):
+    monkeypatch.setattr(model_lm, "BertLM", RecordingBertLM)
+
+    model_lm.ModelLM(
+        model_name_or_path="bert-model",
+        model_type="bert",
+        device="cuda:1",
+        gpu_batch_size=8,
+    )
+
+    assert RecordingBertLM.calls[-1]["device"] == "cuda:1"
+
+
+def test_bert_lm_passes_device_to_scorer_wrapper(monkeypatch):
+    received = {}
+
+    def record_init(self, **kwargs):
+        received.update(kwargs)
+
+    monkeypatch.setattr(bert_lm.MiniconsLM, "__init__", record_init)
+
+    bert_lm.BertLM("bert-model", device="cpu")
+
+    assert received["device"] == "cpu"


### PR DESCRIPTION
## Summary

- add a device argument to `BertLM`
- propagate the requested device through `ModelLM`
- remove the hardcoded masked-reranker CUDA selection
- test CPU and explicit CUDA-device propagation

## Root cause

The public reranker accepted a device value, but the BERT path discarded it and always initialized its scorer with `device="cuda"`.

## Impact

CPU-only reranking and explicit devices such as `cuda:1` now reach the underlying scorer as requested.

## Validation

- focused propagation checks for `cpu` and `cuda:1`
- Python syntax compilation
- `git diff --check`

The full pytest suite was not run locally because the environment lacks its runtime and test dependencies.

Closes #60