### PR TITLE
Restore Transformers 5 tokenizer compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 pip install hashformers
 ```
 
+Hashformers supports Transformers 4.41 through 5.x.
+
 ### Basic Usage
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-minicons
+minicons>=0.3.39,<0.4
+transformers>=4.41,<6
 twitter-text-python
 ekphrasis
 pandas

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     package_dir={'': 'src'},
     python_requires=">=3.8",
     install_requires=[
-        "minicons",
+        "minicons>=0.3.39,<0.4",
+        "transformers>=4.41,<6",
         "twitter-text-python",
         "pandas"
     ],

--- a/src/hashformers/beamsearch/minicons_lm.py
+++ b/src/hashformers/beamsearch/minicons_lm.py
@@ -3,6 +3,21 @@ from torch.utils.data import DataLoader
 import warnings
 import math
 
+
+def ensure_tokenizer_compatibility(tokenizer):
+    """Provide the tokenizer API expected by the minicons 0.3.39 wheel.
+
+    Args:
+        tokenizer: Hugging Face tokenizer used by the minicons scorer.
+
+    Returns:
+        The tokenizer with a compatible ``batch_encode_plus`` method.
+    """
+    if not callable(getattr(tokenizer, 'batch_encode_plus', None)):
+        tokenizer.batch_encode_plus = tokenizer.__call__
+    return tokenizer
+
+
 class MiniconsLM(object):
     """Score candidate sequences using lower-is-better costs.
 
@@ -14,6 +29,7 @@ class MiniconsLM(object):
 
     def __init__(self, model_name_or_path, device='cuda', gpu_batch_size=20, model_type='IncrementalLMScorer'):
         self.scorer = getattr(scorer, model_type)(model_name_or_path, device)
+        ensure_tokenizer_compatibility(self.scorer.tokenizer)
         self.gpu_batch_size = gpu_batch_size
         self.model_type = model_type
     

--- a/tests/test_tokenizer_compatibility.py
+++ b/tests/test_tokenizer_compatibility.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from hashformers.beamsearch import minicons_lm
+
+
+class TransformersFiveTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return "encoded"
+
+
+class TransformersFourTokenizer(TransformersFiveTokenizer):
+    def batch_encode_plus(self, *args, **kwargs):
+        return "legacy"
+
+
+def test_adds_batch_encode_plus_when_missing():
+    tokenizer = TransformersFiveTokenizer()
+
+    minicons_lm.ensure_tokenizer_compatibility(tokenizer)
+    result = tokenizer.batch_encode_plus(["text"], padding="longest")
+
+    assert result == "encoded"
+    assert tokenizer.calls == [((["text"],), {"padding": "longest"})]
+
+
+def test_preserves_existing_batch_encode_plus():
+    tokenizer = TransformersFourTokenizer()
+    original = tokenizer.batch_encode_plus
+
+    minicons_lm.ensure_tokenizer_compatibility(tokenizer)
+
+    assert tokenizer.batch_encode_plus == original
+    assert tokenizer.batch_encode_plus(["text"]) == "legacy"
+
+
+def test_scorer_receives_compatibility_shim(monkeypatch):
+    tokenizer = TransformersFiveTokenizer()
+
+    class FakeScorer:
+        def __init__(self, model_name_or_path, device):
+            self.tokenizer = tokenizer
+
+    monkeypatch.setattr(
+        minicons_lm,
+        "scorer",
+        SimpleNamespace(MaskedLMScorer=FakeScorer),
+    )
+
+    minicons_lm.MiniconsLM("model", "cpu", model_type="MaskedLMScorer")
+
+    assert callable(tokenizer.batch_encode_plus)


### PR DESCRIPTION
## Summary

- add a temporary tokenizer compatibility helper for the published minicons 0.3.39 wheel
- preserve existing `batch_encode_plus` implementations
- forward missing `batch_encode_plus` calls to the supported callable tokenizer API
- declare explicit minicons and Transformers version ranges
- document supported Transformers versions
- add compatibility tests for both tokenizer interfaces

## Root cause

The published minicons 0.3.39 artifact calls `batch_encode_plus`, which Transformers 5 removed. The corrected minicons source was committed after that PyPI artifact was uploaded.

## Impact

Masked reranking can run under Transformers 5 without requiring users to downgrade Transformers or install minicons from an unreleased Git commit.

## Validation

- focused forwarding and method-preservation checks
- Python syntax compilation
- `git diff --check`

The full pytest suite was not run locally because the environment lacks its runtime and test dependencies.

Closes #61