### PR TITLE
Fix beam, compatibility, and segmentation bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 pip install hashformers
 ```
 
-Hashformers supports Transformers 4.41 through 5.x.
+Hashformers requires Python 3.10 or newer and supports Transformers 4.46.1
+through 5.x.
 
 ### Basic Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 minicons>=0.3.39,<0.4
-transformers>=4.41,<6
+transformers>=4.46.1,<6
 twitter-text-python
 ekphrasis
 pandas

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     url="https://github.com/ruanchaves/hashformers",
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "minicons>=0.3.39,<0.4",
-        "transformers>=4.41,<6",
+        "transformers>=4.46.1,<6",
         "twitter-text-python",
         "pandas"
     ],
@@ -30,8 +30,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/src/hashformers/beamsearch/algorithm.py
+++ b/src/hashformers/beamsearch/algorithm.py
@@ -115,7 +115,10 @@ class Beamsearch(ModelLM):
             Node(item, item.replace(" ", ""), probs[idx]) for idx, item in enumerate(tree)
         ]
         for key, group in itertools.groupby(candidates, key=lambda x: x.characters):
-            sorted_group = sorted(list(group), key=lambda x: x.score)
+            unique_group = {}
+            for candidate in group:
+                unique_group.setdefault(candidate.hypothesis, candidate)
+            sorted_group = sorted(unique_group.values(), key=lambda x: x.score)
             trimmed_group = sorted_group[0:topk]
             trimmed_group = [x.hypothesis for x in trimmed_group]
             output.extend(trimmed_group)

--- a/src/hashformers/segmenter/regex_segmenter.py
+++ b/src/hashformers/segmenter/regex_segmenter.py
@@ -46,9 +46,10 @@ class RegexWordSegmenter(BaseSegmenter):
         Yields:
             str: The segmented word.
         """
-        for rule in self.regex_rules:
-            for idx, word in enumerate(word_list):
-                yield self.segment_word(rule, word)
+        for word in word_list:
+            for rule in self.regex_rules:
+                word = self.segment_word(rule, word)
+            yield word
 
     def segment(self, inputs: list[str], **kwargs):
         """

--- a/src/hashformers/segmenter/segmenter.py
+++ b/src/hashformers/segmenter/segmenter.py
@@ -11,7 +11,6 @@ from hashformers.segmenter.data_structures import (
 import re
 from functools import reduce
 import dataclasses
-import pandas as pd
 
 
 class BaseWordSegmenter(BaseSegmenter):
@@ -109,7 +108,7 @@ class BaseWordSegmenter(BaseSegmenter):
         """
         word_list = super().preprocess(word_list, **preprocessing_kwargs)
 
-        if not isinstance(segmenter_run, pd.DataFrame):
+        if segmenter_run is None:
             segmenter_run = self.segmenter_model.run(
                 word_list,
                 **segmenter_kwargs
@@ -132,6 +131,12 @@ class BaseWordSegmenter(BaseSegmenter):
                 **ensembler_kwargs
             )
             segs = ensemble_prob_dict.get_segmentations(
+                astype="list",
+                gold_array=word_list
+            )
+
+        elif use_reranker and self.reranker_model:
+            segs = reranker_run.get_segmentations(
                 astype="list",
                 gold_array=word_list
             )

--- a/tests/test_beam_pruning_deduplication.py
+++ b/tests/test_beam_pruning_deduplication.py
@@ -1,0 +1,52 @@
+from hashformers.beamsearch.algorithm import Beamsearch
+
+
+def build_beamsearch():
+    """Build a beam search instance without loading a language model.
+
+    Returns:
+        Beamsearch: An uninitialized instance suitable for testing ``trim_tree``.
+    """
+    return object.__new__(Beamsearch)
+
+
+def test_duplicate_hypotheses_do_not_consume_beam_slots():
+    beamsearch = build_beamsearch()
+    tree = ["a b cd", "a b cd", "ab cd", "abc d"]
+    scores = {"a b cd": 1, "ab cd": 2, "abc d": 3}
+
+    result = beamsearch.trim_tree(tree, scores, topk=2)
+
+    assert result == ["a b cd", "ab cd"]
+
+
+def test_trim_tree_preserves_input_order_when_scores_are_tied():
+    beamsearch = build_beamsearch()
+    tree = ["ab cd", "a bcd", "abc d"]
+    scores = {"ab cd": 2, "a bcd": 1, "abc d": 1}
+
+    result = beamsearch.trim_tree(tree, scores, topk=2)
+
+    assert result == ["a bcd", "abc d"]
+
+
+def test_trim_tree_deduplicates_character_groups_independently():
+    beamsearch = build_beamsearch()
+    tree = [
+        "a b cd",
+        "a b cd",
+        "ab cd",
+        "w x yz",
+        "w x yz",
+        "wx yz",
+    ]
+    scores = {
+        "a b cd": 1,
+        "ab cd": 2,
+        "w x yz": 4,
+        "wx yz": 3,
+    }
+
+    result = beamsearch.trim_tree(tree, scores, topk=2)
+
+    assert result == ["a b cd", "ab cd", "wx yz", "w x yz"]

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -1,0 +1,41 @@
+import runpy
+from pathlib import Path
+
+import setuptools
+
+
+ROOT = Path(__file__).parent.parent
+
+
+def read_setup_kwargs(monkeypatch):
+    """Execute setup.py while recording its package metadata.
+
+    Args:
+        monkeypatch: Pytest fixture used to replace ``setuptools.setup``.
+
+    Returns:
+        The keyword arguments passed to ``setuptools.setup``.
+    """
+    captured = {}
+    monkeypatch.setattr(setuptools, "setup", lambda **kwargs: captured.update(kwargs))
+    monkeypatch.chdir(ROOT)
+    runpy.run_path(str(ROOT / "setup.py"))
+    return captured
+
+
+def test_supported_python_and_transformers_versions(monkeypatch):
+    metadata = read_setup_kwargs(monkeypatch)
+
+    assert metadata["python_requires"] == ">=3.10"
+    assert "transformers>=4.46.1,<6" in metadata["install_requires"]
+    assert "Programming Language :: Python :: 3.8" not in metadata["classifiers"]
+    assert "Programming Language :: Python :: 3.9" not in metadata["classifiers"]
+
+
+def test_dependency_files_and_readme_match_package_metadata():
+    requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "transformers>=4.46.1,<6" in requirements
+    assert "Python 3.10 or newer" in readme
+    assert "Transformers 4.46.1" in readme

--- a/tests/test_regex_segmenter_multiple_rules.py
+++ b/tests/test_regex_segmenter_multiple_rules.py
@@ -1,0 +1,43 @@
+from hashformers import RegexWordSegmenter, TweetSegmenter
+
+
+def test_default_rule_preserves_single_rule_behavior():
+    """Verify that the default camel-case segmentation remains unchanged.
+
+    The multiple-rule fix must preserve existing behavior for the default rule.
+    """
+    segmenter = RegexWordSegmenter()
+
+    assert segmenter.segment(["UnaGenialidad"]) == ["Una Genialidad"]
+
+
+def test_multiple_rules_are_applied_sequentially_per_input():
+    """Verify that every rule transforms each input before it is emitted.
+
+    Two rules applied to two inputs must produce two outputs, in input order.
+    """
+    segmenter = RegexWordSegmenter(
+        regex_rules=[r"([A-Z]+)", r"([0-9]+)"]
+    )
+
+    assert segmenter.segment(["fooBAR123", "zipZIP456"]) == [
+        "foo BAR 123",
+        "zip ZIP 456",
+    ]
+
+
+def test_tweet_segmenter_receives_one_segmentation_per_hashtag():
+    """Verify that multiple rules keep tweet hashtag replacements aligned.
+
+    Each unique hashtag must receive exactly one fully transformed segmentation.
+    """
+    matcher = lambda tweets: [["fooBAR123"], ["zipZIP456"]]
+    word_segmenter = RegexWordSegmenter(
+        regex_rules=[r"([A-Z]+)", r"([0-9]+)"]
+    )
+    segmenter = TweetSegmenter(matcher=matcher, word_segmenter=word_segmenter)
+
+    result = segmenter.segment(["First #fooBAR123", "Second #zipZIP456"])
+
+    assert result.output == ["First foo BAR 123", "Second zip ZIP 456"]
+    assert len(result.word_segmenter_output.output) == 2

--- a/tests/test_segmenter_run_selection.py
+++ b/tests/test_segmenter_run_selection.py
@@ -1,0 +1,126 @@
+from unittest.mock import Mock
+
+import pandas as pd
+
+from hashformers.beamsearch.data_structures import ProbabilityDictionary
+from hashformers.segmenter.segmenter import BaseWordSegmenter
+
+
+def _scores(preferred_segmentation):
+    alternatives = {
+        "foo bar": 1.0,
+        "fo obar": 1.0,
+    }
+    alternatives[preferred_segmentation] = 0.0
+    return ProbabilityDictionary(alternatives)
+
+
+def test_reranker_output_is_used_when_ensemble_is_disabled():
+    segmenter_run = _scores("foo bar")
+    reranker_run = _scores("fo obar")
+    segmenter_model = Mock()
+    segmenter_model.run.return_value = segmenter_run
+    reranker_model = Mock()
+    reranker_model.rerank.return_value = reranker_run
+    ensembler = Mock()
+    segmenter = BaseWordSegmenter(segmenter_model, reranker_model, ensembler)
+
+    result = segmenter.segment(["foobar"], use_ensembler=False)
+
+    assert result == ["fo obar"]
+    reranker_model.rerank.assert_called_once_with(segmenter_run)
+    ensembler.run.assert_not_called()
+
+
+def test_reranker_output_is_used_when_no_ensembler_is_configured():
+    segmenter_run = _scores("foo bar")
+    reranker_run = _scores("fo obar")
+    segmenter_model = Mock()
+    segmenter_model.run.return_value = segmenter_run
+    reranker_model = Mock()
+    reranker_model.rerank.return_value = reranker_run
+    segmenter = BaseWordSegmenter(segmenter_model, reranker_model)
+
+    result = segmenter.segment(["foobar"])
+
+    assert result == ["fo obar"]
+    reranker_model.rerank.assert_called_once_with(segmenter_run)
+
+
+def test_ensemble_output_still_takes_precedence():
+    segmenter_run = _scores("foo bar")
+    reranker_run = _scores("fo obar")
+    ensemble_run = _scores("foo bar")
+    segmenter_model = Mock()
+    segmenter_model.run.return_value = segmenter_run
+    reranker_model = Mock()
+    reranker_model.rerank.return_value = reranker_run
+    ensembler = Mock()
+    ensembler.run.return_value = ensemble_run
+    segmenter = BaseWordSegmenter(segmenter_model, reranker_model, ensembler)
+
+    result = segmenter.segment(["foobar"])
+
+    assert result == ["foo bar"]
+    reranker_model.rerank.assert_called_once_with(segmenter_run)
+    ensembler.run.assert_called_once_with(segmenter_run, reranker_run)
+
+
+def test_segmenter_output_is_used_when_reranking_is_disabled():
+    segmenter_run = _scores("foo bar")
+    segmenter_model = Mock()
+    segmenter_model.run.return_value = segmenter_run
+    reranker_model = Mock()
+    segmenter = BaseWordSegmenter(segmenter_model, reranker_model)
+
+    result = segmenter.segment(["foobar"], use_reranker=False)
+
+    assert result == ["foo bar"]
+    reranker_model.rerank.assert_not_called()
+
+
+def test_precomputed_probability_dictionary_skips_segmenter_model():
+    precomputed_run = _scores("foo bar")
+    segmenter_model = Mock()
+    segmenter = BaseWordSegmenter(segmenter_model)
+
+    result = segmenter.segment(
+        ["foobar"],
+        segmenter_run=precomputed_run,
+        use_reranker=False,
+    )
+
+    assert result == ["foo bar"]
+    segmenter_model.run.assert_not_called()
+
+
+def test_precomputed_dataframe_still_skips_segmenter_model():
+    precomputed_run = pd.DataFrame(
+        [
+            {"segmentation": "foo bar", "score": 0.0},
+            {"segmentation": "fo obar", "score": 1.0},
+        ]
+    )
+    segmenter_model = Mock()
+    segmenter = BaseWordSegmenter(segmenter_model)
+
+    result = segmenter.segment(
+        ["foobar"],
+        segmenter_run=precomputed_run,
+        use_reranker=False,
+    )
+
+    assert result == ["foo bar"]
+    segmenter_model.run.assert_not_called()
+
+
+def test_omitted_segmenter_run_still_invokes_segmenter_model():
+    model_run = _scores("foo bar")
+    segmenter_model = Mock()
+    segmenter_model.run.return_value = model_run
+    segmenter = BaseWordSegmenter(segmenter_model)
+
+    result = segmenter.segment(["foobar"], use_reranker=False)
+
+    assert result == ["foo bar"]
+    segmenter_model.run.assert_called_once_with(["foobar"])


### PR DESCRIPTION
## Summary

- deduplicate equivalent hypotheses before beam pruning so duplicates do not consume beam slots
- align the declared Python and Transformers compatibility with versions the package supports
- use reranker output when the ensemble is disabled
- honor precomputed ProbabilityDictionary segmenter runs
- apply multiple regex segmentation rules sequentially and emit one result per input

## Root causes

The affected paths either discarded already-computed results, accepted duplicated beam states, or declared/runtime-handled inputs differently from their documented contract. Each fix is intentionally local and includes a regression test.

## Validation

- 26 CPU-safe tests passed with Transformers 4.46.1
- the same 26 tests passed with Transformers 5.14.1
- verified the package import and AutoModelForImageTextToText import at the supported Transformers lower bound
- uv pip check passed
- python -m compileall -q src tests passed

The complete suite cannot collect in this CPU-only environment because tests/test_segmenter.py intentionally raises when CUDA is unavailable; that behavior predates this branch.

Closes #69
Closes #70
Closes #71
Closes #72
Closes #73