### PR TITLE
Expose complete Hashformers workflows over MCP

### DIFF
--- a/.agents/skills/segment-hashtags/SKILL.md
+++ b/.agents/skills/segment-hashtags/SKILL.md
@@ -1,54 +1,123 @@
 ---
 name: segment-hashtags
-description: Segment hashtags with the Hashformers MCP tool. Use when a user asks to split or decompound one or more hashtags, obtain the best segmentation, or compare ranked segmentation candidates and their scores.
+description: Segment hashtags or tweets, process hashtag files without copying their contents into agent context, apply regex rules, and rank precomputed segmentation candidates with the Hashformers MCP server. Use when a user asks to split or decompound hashtags, run bulk local segmentation, replace hashtags in tweets, compare candidates, rerank hypotheses, or inspect component scores.
 ---
 
-# Segment Hashtags
+# Segment with Hashformers
 
-Use the configured Hashformers MCP server for segmentation. Never reproduce the
-segmentation algorithm, load a model directly, or guess a segmentation when the
-tool is unavailable.
+Use the configured Hashformers MCP server. Never reproduce the algorithm, load a
+model directly, or guess segmentations when the tools are unavailable.
 
 ## Workflow
 
-1. Confirm that the Hashformers MCP tool `segment_hashtags` is available. If it
-   is unavailable, explain that the local Hashformers MCP server must be
-   installed and configured, then stop.
-2. Pass all requested hashtags together in the `hashtags` array, preserving
-   their spelling, order, and duplicates.
-3. Include `top_k` only when the user requests a particular number of ranked
-   candidates. It must be an integer greater than zero.
-4. Call `segment_hashtags` once. Do not invoke package code or implement a
-   fallback segmentation.
-5. Report each `selected_segmentation`. Include the ordered `candidates` and
-   their `score` values when the user asks for alternatives or ranking details.
+1. Confirm that the required Hashformers MCP tool is available. If it is not,
+   explain that `hashformers[mcp]` must be installed and `hashformers-mcp`
+   configured, then stop.
+2. Choose one tool:
+   - Use `start_hashtag_file_job`, then `continue_hashtag_file_job`, when the
+     user identifies a local input file.
+   - Use `segment_tweets` for complete tweets whose hashtags must be replaced.
+   - Use `segment_with_regex` when the user requests deterministic regex rules.
+   - Use `rank_candidates` for hypotheses and scores already supplied by the
+     user or another tool.
+   - Otherwise use `segment_hashtags`.
+3. Preserve input spelling, order, and duplicates. Put up to 64 interactive
+   hashtags in one call instead of calling once per hashtag. Split larger
+   inline requests into ordered batches; use file jobs when the input is a file.
+4. Include nondefault options only when the user requests them or they are
+   necessary for the task.
+5. Report selected segmentations. Include candidates or component rankings only
+   when requested.
 
-## Tool Contract
+## Large Files
 
-Call `segment_hashtags` with:
+Pass file paths to `start_hashtag_file_job`; never read the whole file and copy
+its hashtags into a tool argument. The server indexes text, CSV, or JSON Lines,
+deduplicates normalized hashtags, and creates a persistent local checkpoint.
 
-- `hashtags`: a list of hashtag strings.
-- `top_k`: an optional positive integer limiting candidates per hashtag. It
-  defaults to 5.
+Pass the returned `job_path` to `continue_hashtag_file_job`. Keep calling it
+until `status` is `completed`; each call processes a bounded number of unique
+hashtags and can be retried after a timeout or client restart. If the user asks
+to stop, make no further continuation calls. No work runs in the background.
 
-Expect a JSON-serializable object whose `results` list preserves input order:
+Use `input_field` when a CSV column or JSON object field is not named `hashtag`.
+Let the server derive an output path unless the user specifies one. Set
+`overwrite=true` only when the user explicitly authorizes replacing the target
+and the server was started with `--allow-file-overwrite`. File paths must be
+inside a directory authorized by the server's `--file-root` startup option.
+
+After the call, report the output path and summary counts. Do not open or print
+the complete output file unless the user explicitly asks; doing so would place
+the dataset back into agent context. If verification is requested, inspect only
+the requested rows or a small sample.
+
+## Transformer Options
+
+For `segment_hashtags`, Transformer-mode `segment_tweets`, and file jobs:
+
+- `top_k` is the beam-search width and can change the selected segmentation.
+- `steps` is the beam-search depth. MCP calls cap `top_k` at 64 and `steps` at
+  32 to keep requests bounded. The server can also reject a batch whose combined
+  input lengths, beam width, and depth exceed its aggregate work budget; retry a
+  smaller batch or reduce `top_k` or `steps`.
+- `max_candidates` only limits serialized alternatives; it does not narrow the
+  search. It must be between 1 and 64.
+- `ranking_strategy` can be `auto`, `segmenter`, `reranker`, or `ensemble`.
+  Reranker and ensemble strategies require a reranker configured when the MCP
+  server starts.
+- `alpha` and `beta` configure ensemble selection.
+- `lower`, `remove_hashtag`, and `hashtag_character` configure preprocessing.
+- `include_component_rankings=true` returns segmenter, reranker, and ensemble
+  rankings that actually ran.
+
+Model names, scorer types, devices, and model batch sizes are server-startup
+settings. They cannot be changed by an ordinary tool call. If the configured
+model is unsuitable, tell the user which `hashformers-mcp` startup option must
+change rather than silently choosing another model.
+
+## Tool Contracts
+
+Call `segment_hashtags` with a `hashtags` list and optional Transformer options.
+Expect a `results` list preserving input order. Each item contains the original
+and normalized input, selected segmentation, selected ranking strategy, ordered
+lower-is-better candidates, and optional component rankings.
+
+Call `start_hashtag_file_job` with `input_path` and optional `output_path`,
+`input_format`, `input_field`, `overwrite`, and Transformer options. It indexes
+the file without model inference and returns a persistent `job_path`.
+
+Call `continue_hashtag_file_job` with that path and optional
+`max_unique_hashtags`. Expect only paths, checkpoint counts, and active model
+metadata. Repeat while status is `in_progress`; segmentation records appear in
+the final output file only when the job completes. The maximum value is 64;
+call the tool repeatedly instead of requesting a larger chunk.
+
+Call `segment_with_regex` with `inputs` and optional ordered `regex_rules` and
+preprocessing options. Rules are applied sequentially to each input.
+
+Call `segment_tweets` with `tweets` and `segmenter_kind` set to `regex` or
+`transformer`. It returns transformed text and per-occurrence hashtag results.
+Tweet extraction supports the standard `#` marker only.
+
+Call `rank_candidates` with candidate sets shaped as:
 
 ```json
 {
-  "results": [
+  "candidate_sets": [
     {
-      "input": "#examplehashtag",
-      "selected_segmentation": "example hashtag",
+      "input": "#icecold",
       "candidates": [
-        {"segmentation": "example hashtag", "score": 1.23}
+        {"segmentation": "ice cold", "score": 1.2},
+        {"segmentation": "i ce cold", "score": 2.3}
       ]
     }
-  ]
+  ],
+  "ranking_strategy": "segmenter"
 }
 ```
 
-Candidates are ordered best first; lower scores are better. Do not reorder them
-or compare scores across different hashtags.
+Use `segmenter` to select from supplied scores without loading a model. Use
+`reranker` or `ensemble` only when the server has a configured reranker.
 
 ## Examples
 
@@ -58,8 +127,32 @@ For “Segment `#blacklivesmatter`,” call:
 {"hashtags": ["#blacklivesmatter"]}
 ```
 
-For “Show the top three candidates for `#therapist`,” call:
+For “Show the top three returned candidates using a beam width of 20,” call:
 
 ```json
-{"hashtags": ["#therapist"], "top_k": 3}
+{
+  "hashtags": ["#therapist"],
+  "top_k": 20,
+  "max_candidates": 3
+}
+```
+
+For “Segment every hashtag in `data/hashtags.csv` without loading it into the
+chat,” call `start_hashtag_file_job`:
+
+```json
+{
+  "input_path": "data/hashtags.csv",
+  "input_field": "hashtag"
+}
+```
+
+Then call `continue_hashtag_file_job` with the returned checkpoint until it
+completes:
+
+```json
+{
+  "job_path": "/absolute/path/hashtags.jsonl.job.sqlite3",
+  "max_unique_hashtags": 64
+}
 ```

--- a/.agents/skills/segment-hashtags/SKILL.md
+++ b/.agents/skills/segment-hashtags/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: segment-hashtags
+description: Segment hashtags with the Hashformers MCP tool. Use when a user asks to split or decompound one or more hashtags, obtain the best segmentation, or compare ranked segmentation candidates and their scores.
+---
+
+# Segment Hashtags
+
+Use the configured Hashformers MCP server for segmentation. Never reproduce the
+segmentation algorithm, load a model directly, or guess a segmentation when the
+tool is unavailable.
+
+## Workflow
+
+1. Confirm that the Hashformers MCP tool `segment_hashtags` is available. If it
+   is unavailable, explain that the local Hashformers MCP server must be
+   installed and configured, then stop.
+2. Pass all requested hashtags together in the `hashtags` array, preserving
+   their spelling, order, and duplicates.
+3. Include `top_k` only when the user requests a particular number of ranked
+   candidates. It must be an integer greater than zero.
+4. Call `segment_hashtags` once. Do not invoke package code or implement a
+   fallback segmentation.
+5. Report each `selected_segmentation`. Include the ordered `candidates` and
+   their `score` values when the user asks for alternatives or ranking details.
+
+## Tool Contract
+
+Call `segment_hashtags` with:
+
+- `hashtags`: a list of hashtag strings.
+- `top_k`: an optional positive integer limiting candidates per hashtag. It
+  defaults to 5.
+
+Expect a JSON-serializable object whose `results` list preserves input order:
+
+```json
+{
+  "results": [
+    {
+      "input": "#examplehashtag",
+      "selected_segmentation": "example hashtag",
+      "candidates": [
+        {"segmentation": "example hashtag", "score": 1.23}
+      ]
+    }
+  ]
+}
+```
+
+Candidates are ordered best first; lower scores are better. Do not reorder them
+or compare scores across different hashtags.
+
+## Examples
+
+For “Segment `#blacklivesmatter`,” call:
+
+```json
+{"hashtags": ["#blacklivesmatter"]}
+```
+
+For “Show the top three candidates for `#therapist`,” call:
+
+```json
+{"hashtags": ["#therapist"], "top_k": 3}
+```

--- a/.agents/skills/segment-hashtags/agents/openai.yaml
+++ b/.agents/skills/segment-hashtags/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Segment Hashtags"
+  short_description: "Segment hashtags with Hashformers MCP"
+  default_prompt: "Use $segment-hashtags to segment these hashtags with Hashformers."

--- a/.agents/skills/segment-hashtags/agents/openai.yaml
+++ b/.agents/skills/segment-hashtags/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Segment Hashtags"
-  short_description: "Segment hashtags with Hashformers MCP"
-  default_prompt: "Use $segment-hashtags to segment these hashtags with Hashformers."
+  display_name: "Segment with Hashformers"
+  short_description: "Segment hashtags, tweets, files, and candidates"
+  default_prompt: "Use $segment-hashtags to segment these hashtags or files with Hashformers."

--- a/README.md
+++ b/README.md
@@ -94,26 +94,68 @@ pip install "hashformers[mcp]"
 ```
 
 The core `pip install hashformers` installation does not include the MCP SDK.
-Start the server over stdio with:
+Start the server over stdio with the same model settings accepted by the Python
+API:
 
 ```bash
-hashformers-mcp
+hashformers-mcp \
+  --model distilgpt2 \
+  --batch-size 64 \
+  --file-root /path/to/project
 ```
+
+Optional startup flags configure the segmenter model and scorer type, device,
+and batch size. Supplying `--reranker-model` enables reranker-only and ensemble
+selection, with corresponding model-type, device, and batch-size flags. Run
+`hashformers-mcp --help` for the complete list. Models are loaded lazily and
+reused for the life of the process; `auto` selects CUDA when available and
+otherwise uses CPU. File-job tools are restricted to the server working
+directory by default; repeat `--file-root` to authorize other directories.
+File jobs currently require Linux descriptor-backed filesystem support through
+`/proc/self/fd`; the interactive, regex, tweet, and candidate-ranking tools
+remain available on other platforms.
 
 MCP clients normally launch that command for you. For example, configure Codex
 or Claude Code with:
 
 ```bash
-codex mcp add hashformers -- hashformers-mcp
-claude mcp add --transport stdio --scope user hashformers -- hashformers-mcp
+codex mcp add hashformers -- hashformers-mcp --model distilgpt2
+claude mcp add --transport stdio --scope user hashformers -- \
+  hashformers-mcp --model distilgpt2
 ```
 
-The server exposes one tool, `segment_hashtags`, which accepts a `hashtags`
-list and an optional positive `top_k` (default: 5). It returns the selected
-segmentation and up to `top_k` lower-is-better scored candidates for each input.
-The Transformer segmenter is initialized on the first tool call and reused for
-the life of the server process. CUDA is selected when available, with CPU as a
-fallback.
+The server exposes the complete user-facing segmentation workflow:
+
+| Tool | Purpose |
+|------|---------|
+| `segment_hashtags` | Run Transformer beam search with configurable search depth, preprocessing, reranker or ensemble selection, and component rankings. |
+| `start_hashtag_file_job` | Index and deduplicate text, CSV, or JSON Lines locally without loading a model or placing the dataset in agent context. |
+| `continue_hashtag_file_job` | Process and atomically checkpoint one bounded batch of a file job; repeat until completion. |
+| `segment_with_regex` | Apply the library's ordered regex rules without loading a model. |
+| `segment_tweets` | Extract and replace hashtags in full tweets with either regex or Transformer segmentation. |
+| `rank_candidates` | Select, rerank, or ensemble precomputed hypotheses without rerunning beam search. |
+
+`top_k` controls beam width while `max_candidates` independently limits the
+returned or written alternatives and is capped at 64. Model identity, devices,
+and GPU batch sizes are startup settings so an agent cannot accidentally
+download or retain several models during ordinary calls. Interactive
+Transformer calls accept at most 64 inputs, `top_k` is capped at 64, and `steps`
+at 32. An aggregate expansion budget also rejects combinations of long inputs,
+wide beams, and deep searches that would still consume excessive memory. Larger
+inputs belong in the resumable file workflow.
+
+For large local datasets, pass only paths to `start_hashtag_file_job`. A text
+file contains one hashtag per line; CSV and JSON Lines inputs use the `hashtag`
+field by default. Repeatedly call `continue_hashtag_file_job` with the returned
+job path until its status is `completed`. Each call processes at most 64 unique
+hashtags by default and persists an atomic SQLite checkpoint, so client timeouts
+or restarts do not lose completed work. The final JSON Lines file preserves
+every source row and duplicate in order. Full inputs and results never consume
+agent-context tokens unless the user later asks the agent to open the output.
+The checkpoint contains the indexed inputs, so continuation does not repeatedly
+reread the source file. Existing outputs are never replaced unless the server
+was started with `--allow-file-overwrite` and the caller also passes
+`overwrite=true`.
 
 This repository also includes the `segment-hashtags` Agent Skill at
 `.agents/skills/segment-hashtags`. Codex discovers it automatically when run
@@ -133,8 +175,8 @@ cp -R .agents/skills/segment-hashtags ~/.claude/skills/
 ```
 
 Restart the client if a newly created skill directory is not detected. The
-Skill calls the MCP tool and does not implement segmentation itself, so the MCP
-server must also be installed and configured.
+Skill chooses the appropriate MCP workflow and does not implement segmentation
+itself, so the MCP server must also be installed and configured.
 
 ## When to Use Hashformers?
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,57 @@ Install with spaCy support:
 pip install hashformers[spacy]
 ```
 
+### MCP and Agent Skill
+
+Install the optional local MCP server on Python 3.10 or newer:
+
+```bash
+pip install "hashformers[mcp]"
+```
+
+The core `pip install hashformers` installation does not include the MCP SDK.
+Start the server over stdio with:
+
+```bash
+hashformers-mcp
+```
+
+MCP clients normally launch that command for you. For example, configure Codex
+or Claude Code with:
+
+```bash
+codex mcp add hashformers -- hashformers-mcp
+claude mcp add --transport stdio --scope user hashformers -- hashformers-mcp
+```
+
+The server exposes one tool, `segment_hashtags`, which accepts a `hashtags`
+list and an optional positive `top_k` (default: 5). It returns the selected
+segmentation and up to `top_k` lower-is-better scored candidates for each input.
+The Transformer segmenter is initialized on the first tool call and reused for
+the life of the server process. CUDA is selected when available, with CPU as a
+fallback.
+
+This repository also includes the `segment-hashtags` Agent Skill at
+`.agents/skills/segment-hashtags`. Codex discovers it automatically when run
+from this repository. To make it available from every project, copy it to the
+user skill directory:
+
+```bash
+mkdir -p ~/.agents/skills
+cp -R .agents/skills/segment-hashtags ~/.agents/skills/
+```
+
+Claude Code uses a different discovery directory:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R .agents/skills/segment-hashtags ~/.claude/skills/
+```
+
+Restart the client if a newly created skill directory is not detected. The
+Skill calls the MCP tool and does not implement segmentation itself, so the MCP
+server must also be installed and configured.
+
 ## When to Use Hashformers?
 
 The table below outlines when to use **Hashformers** versus other approaches like heuristic-based splitters (e.g., SymSpell, WordNinja) or large LLMs.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ setup(
         "pandas"
     ],
     extras_require={
+        "mcp": ["mcp>=2,<3"],
         "spacy": ["spacy>=3.0.0"]
+    },
+    entry_points={
+        "console_scripts": [
+            "hashformers-mcp=hashformers.mcp_server:main",
+        ]
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "pandas"
     ],
     extras_require={
-        "mcp": ["mcp>=2,<3"],
+        "mcp": ["anyio>=4.9", "mcp>=2,<3", "regex"],
         "spacy": ["spacy>=3.0.0"]
     },
     entry_points={

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -1,164 +1,3141 @@
-"""Expose Hashformers hashtag segmentation through a local MCP server.
+"""Expose Hashformers segmentation workflows through a local MCP server.
 
-The module registers one structured tool and runs it over stdio for local MCP
-clients.
 """
 
+import csv
+import hashlib
+import json
+import math
+import os
+import secrets
+import sqlite3
+import stat
+from argparse import ArgumentParser
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
 from threading import Lock
+from typing import Literal, TextIO
 
+import anyio
+import regex as timeout_regex
 import torch
 from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
+from mcp.types import ToolAnnotations
 from typing_extensions import TypedDict
 
+from hashformers.beamsearch.data_structures import ProbabilityDictionary
+from hashformers.segmenter import (
+    BaseWordSegmenter,
+    RegexWordSegmenter,
+    TweetSegmenter,
+    TwitterTextMatcher,
+)
 from hashformers.segmenter.auto import TransformerWordSegmenter
+from hashformers.segmenter.data_structures import HashtagContainer, WordSegmenterOutput
+
+RankingStrategy = Literal["auto", "segmenter", "reranker", "ensemble"]
+ResolvedRankingStrategy = Literal["segmenter", "reranker", "ensemble"]
+SegmenterKind = Literal["regex", "transformer"]
+FileInputFormat = Literal["auto", "text", "csv", "jsonl"]
+
+MAX_INTERACTIVE_INPUTS = 64
+MAX_FILE_UNIQUE_HASHTAGS = 64
+MAX_TOP_K = 64
+MAX_STEPS = 32
+MAX_BEAM_EXPANSIONS = 250_000
+MAX_RETURNED_CANDIDATES = 64
+MAX_PRECOMPUTED_CANDIDATES = 4096
+MAX_HASHTAG_LENGTH = 512
+MAX_REGEX_RULES = 32
+MAX_REGEX_PATTERN_LENGTH = 512
+MAX_REGEX_INPUT_LENGTH = 10_000
+MAX_REGEX_OUTPUT_LENGTH = 20_000
+MAX_TWEET_HASHTAG_OCCURRENCES = 64
+MAX_TWEET_REPLACEMENT_CHARS = 128
+MAX_TWEET_OUTPUT_CHARS = 1_000_000
+MAX_FILE_RECORD_CHARS = 65_536
+MAX_JOB_METADATA_CHARS = 65_536
+MAX_JOB_RESULT_CHARS = 1_000_000
+REGEX_TIMEOUT_SECONDS = 0.1
+JOB_APPLICATION_ID = 0x48464D52
+JOB_SCHEMA_VERSION = 1
+JOB_METADATA_KEYS = (
+    "input_path",
+    "output_path",
+    "input_format",
+    "input_field",
+    "input_hash",
+    "overwrite",
+    "finalized",
+    "server_config",
+    "run_options",
+)
+JOB_TABLE_SCHEMAS = {
+    "metadata": (
+        ("key", "TEXT", 0, 1),
+        ("value", "TEXT", 1, 0),
+    ),
+    "source_records": (
+        ("source_line", "INTEGER", 0, 1),
+        ("input", "TEXT", 1, 0),
+        ("normalized", "TEXT", 1, 0),
+    ),
+    "unique_hashtags": (
+        ("normalized", "TEXT", 0, 1),
+        ("representative_input", "TEXT", 1, 0),
+        ("result_json", "TEXT", 0, 0),
+    ),
+}
+SUPPORTS_SECURE_DIR_FD = (
+    os.name != "nt"
+    and hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.link in os.supports_dir_fd
+    and os.link in os.supports_follow_symlinks
+    and os.rename in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+)
+DESCRIPTOR_DIRECTORY = (
+    Path("/proc/self/fd") if Path("/proc/self/fd").is_dir() else None
+)
+SUPPORTS_SECURE_FILE_JOBS = (
+    SUPPORTS_SECURE_DIR_FD and DESCRIPTOR_DIRECTORY is not None
+)
+SECURE_FILE_JOB_ERROR = (
+    "secure file jobs are not supported on this platform; use a Linux host "
+    "with /proc/self/fd"
+)
 
 
 class Candidate(TypedDict):
-    """Represent a ranked segmentation candidate.
+    """Represent one ranked segmentation candidate.
 
     Attributes:
         segmentation: Candidate text with inferred word boundaries.
-        score: Language-model score; lower values rank higher.
+        score: Score used for ordering; lower values rank higher.
+        rank: One-based position within the candidate set.
+    """
+
+    segmentation: str
+    score: float
+    rank: int
+
+
+class ComponentRankings(TypedDict):
+    """Represent rankings produced by each configured pipeline component.
+
+    Attributes:
+        segmenter: Candidates scored by the beam-search model.
+        reranker: Candidates scored by the reranker, when used.
+        ensemble: Candidates selected by the ensemble, when used.
+    """
+
+    segmenter: list[Candidate]
+    reranker: list[Candidate] | None
+    ensemble: list[Candidate] | None
+
+
+class SegmentationResult(TypedDict):
+    """Represent a complete segmentation result for one input.
+
+    Attributes:
+        input: Original text supplied by the caller.
+        normalized_input: Text after Hashformers preprocessing.
+        selected_segmentation: Highest-ranked segmentation.
+        ranking_strategy: Component that selected the result.
+        candidates: Ranked candidates from the selected component.
+        component_rankings: Optional rankings for every component that ran.
+    """
+
+    input: str
+    normalized_input: str
+    selected_segmentation: str
+    ranking_strategy: ResolvedRankingStrategy
+    candidates: list[Candidate]
+    component_rankings: ComponentRankings | None
+
+
+class SegmentationsResult(TypedDict):
+    """Represent a list of segmentation results.
+
+    Attributes:
+        results: Per-input results in input order.
+    """
+
+    results: list[SegmentationResult]
+
+
+class RegexSegmentationResult(TypedDict):
+    """Represent one deterministic regex segmentation.
+
+    Attributes:
+        input: Original text supplied by the caller.
+        normalized_input: Text after Hashformers preprocessing.
+        segmentation: Text after applying every regex rule in order.
+    """
+
+    input: str
+    normalized_input: str
+    segmentation: str
+
+
+class RegexSegmentationsResult(TypedDict):
+    """Represent regex segmentation results.
+
+    Attributes:
+        results: Per-input results in input order.
+    """
+
+    results: list[RegexSegmentationResult]
+
+
+class TweetSegmentationResult(TypedDict):
+    """Represent one tweet after its hashtags have been segmented.
+
+    Attributes:
+        input: Original tweet.
+        segmented_text: Tweet with segmented hashtags substituted.
+        hashtags: Segmentation details in hashtag occurrence order.
+    """
+
+    input: str
+    segmented_text: str
+    hashtags: list[SegmentationResult]
+
+
+class TweetSegmentationsResult(TypedDict):
+    """Represent tweet segmentation results.
+
+    Attributes:
+        results: Per-tweet results in input order.
+    """
+
+    results: list[TweetSegmentationResult]
+
+
+class ScoredCandidateInput(TypedDict):
+    """Represent a caller-supplied candidate and segmenter score.
+
+    Attributes:
+        segmentation: Candidate segmentation.
+        score: Existing lower-is-better segmenter score.
     """
 
     segmentation: str
     score: float
 
 
-class SegmentationResult(TypedDict):
-    """Represent the segmentation result for one input hashtag.
+class CandidateSetInput(TypedDict):
+    """Represent precomputed candidates for one unsegmented input.
 
     Attributes:
-        input: Original hashtag supplied by the caller.
-        selected_segmentation: Highest-ranked segmentation.
-        candidates: Ranked segmentation alternatives.
+        input: Original unsegmented text.
+        candidates: Hypotheses with their existing segmenter scores.
     """
 
     input: str
-    selected_segmentation: str
-    candidates: list[Candidate]
+    candidates: list[ScoredCandidateInput]
 
 
-class SegmentHashtagsResult(TypedDict):
-    """Represent the structured result returned by ``segment_hashtags``.
+class FileJobStatus(TypedDict):
+    """Summarize a resumable file job without returning segmentation data.
 
     Attributes:
-        results: Per-input segmentation results in input order.
+        job_path: Persistent local checkpoint passed to continuation calls.
+        input_path: Absolute path read by the MCP server.
+        output_path: Absolute JSON Lines path written by the MCP server.
+        input_format: Resolved input format.
+        status: Whether more continuation calls are required.
+        total_hashtags: Number of source records indexed.
+        unique_hashtags: Number of distinct normalized inputs encountered.
+        deduplicated_hashtags: Number of repeated inputs reused from cache.
+        processed_unique: Number of unique hashtags checkpointed.
+        processed_this_call: Number checkpointed by the latest continuation.
+        remaining_unique: Number still requiring inference.
+        segmenter_model: Model that generated beam-search candidates.
+        reranker_model: Optional model used for reranking.
+        ranking_strategy: Component used to select output segmentations.
     """
 
-    results: list[SegmentationResult]
+    job_path: str
+    input_path: str
+    output_path: str
+    input_format: str
+    status: Literal["in_progress", "completed"]
+    total_hashtags: int
+    unique_hashtags: int
+    deduplicated_hashtags: int
+    processed_unique: int
+    processed_this_call: int
+    remaining_unique: int
+    segmenter_model: str
+    reranker_model: str | None
+    ranking_strategy: ResolvedRankingStrategy
 
 
+@dataclass(frozen=True)
+class ServerConfig:
+    """Configure models and memory policy for one MCP server process.
+
+    Attributes:
+        segmenter_model: Hugging Face model name or local path.
+        segmenter_model_type: Hashformers scorer type for beam search.
+        segmenter_device: Device string or ``auto``.
+        segmenter_batch_size: Maximum segmenter inference batch size.
+        reranker_model: Optional Hugging Face reranker name or local path.
+        reranker_model_type: Hashformers scorer type for reranking.
+        reranker_device: Device string or ``inherit``.
+        reranker_batch_size: Maximum reranker inference batch size.
+        file_roots: Directories available to file-job tools.
+        allow_file_overwrite: Whether callers may replace existing files.
+    """
+
+    segmenter_model: str = "gpt2"
+    segmenter_model_type: str = "gpt2"
+    segmenter_device: str = "auto"
+    segmenter_batch_size: int = 64
+    reranker_model: str | None = None
+    reranker_model_type: str = "bert"
+    reranker_device: str = "inherit"
+    reranker_batch_size: int = 64
+    file_roots: tuple[str, ...] = (".",)
+    allow_file_overwrite: bool = False
+
+
+@dataclass(frozen=True)
+class _ConfiguredFileRoot:
+    """Pin one configured file root to its startup filesystem identity.
+
+    Attributes:
+        path: Canonical path captured when the server was configured.
+        descriptor: Process-owned descriptor for the configured directory.
+        device: Filesystem device number for the configured directory.
+        inode: Filesystem inode number for the configured directory.
+    """
+
+    path: Path
+    descriptor: int
+    device: int
+    inode: int
+
+
+_server_config = ServerConfig()
+_configured_file_roots: tuple[_ConfiguredFileRoot, ...] = ()
 _segmenter: TransformerWordSegmenter | None = None
 _segmenter_lock = Lock()
+_file_roots_lock = Lock()
+_inference_lock = Lock()
+
+
+def _positive_integer(value: str) -> int:
+    """Parse a positive integer for the command-line interface.
+
+    Args:
+        value: Raw command-line value.
+
+    Returns:
+        The parsed positive integer.
+
+    Raises:
+        ValueError: If the value is not a positive integer.
+    """
+    parsed = int(value)
+    if parsed < 1:
+        raise ValueError("must be a positive integer")
+    return parsed
+
+
+def build_argument_parser() -> ArgumentParser:
+    """Build the MCP server command-line parser.
+
+    Returns:
+        Parser for model, device, and batch-size configuration.
+    """
+    parser = ArgumentParser(
+        prog="hashformers-mcp",
+        description="Run the Hashformers MCP server over stdio.",
+    )
+    parser.add_argument(
+        "--model",
+        "--segmenter-model",
+        dest="segmenter_model",
+        default="gpt2",
+        help="Hugging Face model name or local path used for beam search.",
+    )
+    parser.add_argument(
+        "--segmenter-model-type",
+        default="gpt2",
+        help="Hashformers scorer type used for beam search.",
+    )
+    parser.add_argument(
+        "--device",
+        "--segmenter-device",
+        dest="segmenter_device",
+        default="auto",
+        help="Segmenter device string; 'auto' selects CUDA when available.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        "--segmenter-batch-size",
+        dest="segmenter_batch_size",
+        type=_positive_integer,
+        default=64,
+        help="Maximum segmenter inference batch size.",
+    )
+    parser.add_argument(
+        "--reranker-model",
+        default=None,
+        help="Optional Hugging Face reranker name or local path.",
+    )
+    parser.add_argument(
+        "--reranker-model-type",
+        default="bert",
+        help="Hashformers scorer type used for reranking.",
+    )
+    parser.add_argument(
+        "--reranker-device",
+        default="inherit",
+        help="Reranker device string; 'inherit' uses the segmenter device.",
+    )
+    parser.add_argument(
+        "--reranker-batch-size",
+        type=_positive_integer,
+        default=64,
+        help="Maximum reranker inference batch size.",
+    )
+    parser.add_argument(
+        "--file-root",
+        action="append",
+        default=None,
+        help=(
+            "Directory file-job tools may read and write. Repeat for multiple "
+            "roots; defaults to the server working directory."
+        ),
+    )
+    parser.add_argument(
+        "--allow-file-overwrite",
+        action="store_true",
+        help="Allow file jobs with overwrite=true to replace existing output.",
+    )
+    return parser
+
+
+def parse_server_config(argv: list[str] | None = None) -> ServerConfig:
+    """Parse process-wide MCP server configuration.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Validated server configuration.
+    """
+    arguments = vars(build_argument_parser().parse_args(argv))
+    arguments["file_roots"] = tuple(arguments.pop("file_root") or ["."])
+    config = ServerConfig(**arguments)
+    _validate_server_config(config)
+    return config
+
+
+def _validate_server_config(config: ServerConfig) -> None:
+    """Validate model and memory settings.
+
+    Args:
+        config: Configuration to validate.
+
+    Raises:
+        ValueError: If a required string is blank or a batch size is invalid.
+    """
+    required_strings = {
+        "segmenter_model": config.segmenter_model,
+        "segmenter_model_type": config.segmenter_model_type,
+        "segmenter_device": config.segmenter_device,
+        "reranker_model_type": config.reranker_model_type,
+        "reranker_device": config.reranker_device,
+    }
+    if config.reranker_model is not None:
+        required_strings["reranker_model"] = config.reranker_model
+    for name, value in required_strings.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{name} must contain text")
+    for name, value in {
+        "segmenter_batch_size": config.segmenter_batch_size,
+        "reranker_batch_size": config.reranker_batch_size,
+    }.items():
+        _validate_positive(value, name)
+    if not isinstance(config.file_roots, tuple) or not config.file_roots:
+        raise ValueError("file_roots must contain at least one directory")
+    for root in config.file_roots:
+        if not isinstance(root, str) or not root.strip():
+            raise ValueError("file_roots must contain directory paths")
+        if not Path(root).expanduser().resolve().is_dir():
+            raise ValueError(f"file root is not a directory: {root}")
+    if not isinstance(config.allow_file_overwrite, bool):
+        raise ValueError("allow_file_overwrite must be a boolean")
+
+
+def configure_server(config: ServerConfig) -> None:
+    """Set process-wide configuration before serving requests.
+
+    Args:
+        config: Model and memory settings for the server process.
+
+    Returns:
+        None.
+    """
+    global _configured_file_roots, _server_config, _segmenter
+    _validate_server_config(config)
+    configured_file_roots = _pin_file_roots(config.file_roots)
+    with _segmenter_lock, _file_roots_lock:
+        previous_file_roots = _configured_file_roots
+        _server_config = config
+        _configured_file_roots = configured_file_roots
+        _segmenter = None
+    for root in previous_file_roots:
+        if root.descriptor >= 0:
+            os.close(root.descriptor)
+
+
+def _model_config_payload() -> dict[str, object]:
+    """Return only the configuration that affects model output.
+
+    Returns:
+        JSON-safe model, device, and batch-size configuration.
+    """
+    return {
+        "segmenter_model": _server_config.segmenter_model,
+        "segmenter_model_type": _server_config.segmenter_model_type,
+        "segmenter_device": _server_config.segmenter_device,
+        "segmenter_batch_size": _server_config.segmenter_batch_size,
+        "reranker_model": _server_config.reranker_model,
+        "reranker_model_type": _server_config.reranker_model_type,
+        "reranker_device": _server_config.reranker_device,
+        "reranker_batch_size": _server_config.reranker_batch_size,
+    }
+
+
+def _resolve_file_path(
+    raw_path: str | Path,
+    name: str,
+    *,
+    must_exist: bool,
+) -> Path:
+    """Resolve and authorize a path against process-wide file roots.
+
+    Args:
+        raw_path: Caller- or checkpoint-provided path.
+        name: Argument name used in an error message.
+        must_exist: Whether every path component must already exist.
+
+    Returns:
+        Canonical authorized path.
+
+    Raises:
+        ValueError: If the path is missing or outside configured roots.
+    """
+    try:
+        resolved = Path(raw_path).expanduser().resolve(strict=must_exist)
+    except (FileNotFoundError, OSError) as error:
+        raise ValueError(f"{name} does not exist: {raw_path}") from error
+    roots = _active_file_roots()
+    if not any(
+        resolved == root.path or resolved.is_relative_to(root.path)
+        for root in roots
+    ):
+        allowed = ", ".join(str(root.path) for root in roots)
+        raise ValueError(f"{name} is outside configured file roots ({allowed})")
+    return resolved
+
+
+def _configured_root_for(path: Path) -> _ConfiguredFileRoot:
+    """Return the canonical configured root containing a resolved path.
+
+    Args:
+        path: Canonical path already authorized by ``_resolve_file_path``.
+
+    Returns:
+        The narrowest pinned root containing the path.
+
+    Raises:
+        ValueError: If no active file root contains the path.
+    """
+    roots = sorted(
+        _active_file_roots(),
+        key=lambda root: len(root.path.parts),
+        reverse=True,
+    )
+    for root in roots:
+        if path == root.path or path.is_relative_to(root.path):
+            return root
+    raise ValueError("path is outside configured file roots")
+
+
+def _open_directory_nofollow(path: Path) -> int:
+    """Open an absolute directory without following path-component symlinks.
+
+    Args:
+        path: Canonical absolute directory path.
+
+    Returns:
+        An owned directory file descriptor.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    if os.name == "nt" or not hasattr(os, "O_NOFOLLOW"):
+        return os.open(path, flags)
+    descriptor = os.open(path.anchor, flags)
+    try:
+        for part in path.parts[1:]:
+            child = os.open(
+                part,
+                flags | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _pin_file_roots(
+    raw_roots: tuple[str, ...],
+) -> tuple[_ConfiguredFileRoot, ...]:
+    """Capture canonical paths and filesystem identities for file roots.
+
+    Args:
+        raw_roots: Operator-configured root directory paths.
+
+    Returns:
+        Immutable root records used for every later authorization check.
+
+    Raises:
+        ValueError: If a configured root cannot be opened as a directory.
+    """
+    configured: list[_ConfiguredFileRoot] = []
+    try:
+        for raw_root in raw_roots:
+            root = Path(raw_root).expanduser().resolve(strict=True)
+            if not SUPPORTS_SECURE_FILE_JOBS:
+                root_stat = root.stat()
+                configured.append(
+                    _ConfiguredFileRoot(
+                        path=root,
+                        descriptor=-1,
+                        device=root_stat.st_dev,
+                        inode=root_stat.st_ino,
+                    )
+                )
+                continue
+            descriptor = _open_directory_nofollow(root)
+            try:
+                root_stat = os.fstat(descriptor)
+                if not stat.S_ISDIR(root_stat.st_mode):
+                    raise ValueError(
+                        f"file root is not a directory: {raw_root}"
+                    )
+            except BaseException:
+                os.close(descriptor)
+                raise
+            configured.append(
+                _ConfiguredFileRoot(
+                    path=root,
+                    descriptor=descriptor,
+                    device=root_stat.st_dev,
+                    inode=root_stat.st_ino,
+                )
+            )
+    except BaseException:
+        for configured_root in configured:
+            if configured_root.descriptor >= 0:
+                os.close(configured_root.descriptor)
+        raise
+    return tuple(configured)
+
+
+def _active_file_roots() -> tuple[_ConfiguredFileRoot, ...]:
+    """Return roots pinned by explicit or lazy server configuration.
+
+    Returns:
+        Immutable configured root records.
+    """
+    global _configured_file_roots
+    if _configured_file_roots:
+        return _configured_file_roots
+    with _file_roots_lock:
+        if not _configured_file_roots:
+            _configured_file_roots = _pin_file_roots(_server_config.file_roots)
+        return _configured_file_roots
+
+
+def _open_pinned_root(root: _ConfiguredFileRoot) -> int:
+    """Open a configured root only if its startup identity is unchanged.
+
+    Args:
+        root: Root path and identity captured during configuration.
+
+    Returns:
+        An owned descriptor for the same configured directory.
+
+    Raises:
+        ValueError: If the configured path was replaced after startup.
+    """
+    descriptor = None
+    visible_descriptor = None
+    try:
+        with _file_roots_lock:
+            if root not in _configured_file_roots:
+                raise ValueError("server file-root configuration changed")
+            descriptor = os.dup(root.descriptor)
+        visible_descriptor = _open_directory_nofollow(root.path)
+        visible_stat = os.fstat(visible_descriptor)
+        if (visible_stat.st_dev, visible_stat.st_ino) != (
+            root.device,
+            root.inode,
+        ):
+            raise ValueError(
+                f"configured file root changed after server startup: {root.path}"
+            )
+        os.close(visible_descriptor)
+        visible_descriptor = None
+        return descriptor
+    except OSError as error:
+        if visible_descriptor is not None:
+            os.close(visible_descriptor)
+        if descriptor is not None:
+            os.close(descriptor)
+        raise ValueError(
+            f"configured file root changed after server startup: {root.path}"
+        ) from error
+    except BaseException:
+        if visible_descriptor is not None:
+            os.close(visible_descriptor)
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
+
+
+def _descriptor_path(descriptor: int) -> Path:
+    """Build a path that remains bound to an already-open descriptor.
+
+    Args:
+        descriptor: Open file or directory descriptor.
+
+    Returns:
+        Descriptor-backed path suitable for SQLite.
+
+    Raises:
+        ValueError: If the platform lacks descriptor-backed filesystem paths.
+    """
+    if not SUPPORTS_SECURE_FILE_JOBS or DESCRIPTOR_DIRECTORY is None:
+        raise ValueError(SECURE_FILE_JOB_ERROR)
+    path = DESCRIPTOR_DIRECTORY / str(descriptor)
+    try:
+        if not os.path.samestat(os.fstat(descriptor), path.stat()):
+            raise ValueError(SECURE_FILE_JOB_ERROR)
+    except OSError as error:
+        raise ValueError(SECURE_FILE_JOB_ERROR) from error
+    return path
+
+
+def _connect_descriptor_database(
+    descriptor: int,
+    *,
+    timeout: float = 0,
+) -> sqlite3.Connection:
+    """Open SQLite through a verified descriptor without pathname fallback.
+
+    Args:
+        descriptor: Open descriptor for an existing regular database file.
+        timeout: SQLite lock wait in seconds.
+
+    Returns:
+        A connection to the same file inode as ``descriptor``.
+
+    Raises:
+        ValueError: If SQLite cannot preserve the descriptor-bound identity.
+    """
+    descriptor_path = _descriptor_path(descriptor)
+    try:
+        connection = sqlite3.connect(
+            f"file:{descriptor_path}?mode=rw",
+            uri=True,
+            timeout=timeout,
+        )
+    except sqlite3.OperationalError as error:
+        raise ValueError(SECURE_FILE_JOB_ERROR) from error
+    try:
+        database_rows = connection.execute("PRAGMA database_list").fetchall()
+        main_rows = [row for row in database_rows if row[1] == "main"]
+        if len(main_rows) != 1 or not main_rows[0][2]:
+            raise ValueError(SECURE_FILE_JOB_ERROR)
+        database_path = Path(main_rows[0][2])
+        if (
+            DESCRIPTOR_DIRECTORY is not None
+            and (
+                database_path == DESCRIPTOR_DIRECTORY
+                or database_path.is_relative_to(DESCRIPTOR_DIRECTORY)
+            )
+        ):
+            raise ValueError(SECURE_FILE_JOB_ERROR)
+        try:
+            same_file = os.path.samestat(
+                os.fstat(descriptor),
+                database_path.stat(),
+            )
+        except OSError as error:
+            raise ValueError(SECURE_FILE_JOB_ERROR) from error
+        if not same_file:
+            raise ValueError(SECURE_FILE_JOB_ERROR)
+        return connection
+    except BaseException:
+        connection.close()
+        raise
+
+
+def _open_authorized_parent(
+    raw_path: str | Path,
+    name: str,
+    *,
+    must_exist: bool,
+) -> tuple[Path, int | None]:
+    """Resolve a path and anchor its parent to a no-follow descriptor.
+
+    Args:
+        raw_path: Caller- or checkpoint-provided path.
+        name: Argument name used in errors.
+        must_exist: Whether the final path must already exist.
+
+    Returns:
+        The canonical path and an owned descriptor for its parent directory.
+
+    Raises:
+        ValueError: If the path is a configured root rather than a child path.
+    """
+    if not SUPPORTS_SECURE_FILE_JOBS:
+        raise ValueError(SECURE_FILE_JOB_ERROR)
+    resolved = _resolve_file_path(raw_path, name, must_exist=must_exist)
+    root = _configured_root_for(resolved)
+    if resolved == root.path:
+        raise ValueError(f"{name} must identify a file inside a configured root")
+    descriptor = _open_pinned_root(root)
+    try:
+        for part in resolved.parent.relative_to(root.path).parts:
+            child = os.open(
+                part,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = child
+        return resolved, descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _open_regular_child(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    flags: int,
+    error_message: str,
+) -> int:
+    """Open an untrusted child without blocking and require a regular file.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback parent path.
+        name: Child basename.
+        flags: Access flags accepted by ``os.open``.
+        error_message: Validation error raised for a special file.
+
+    Returns:
+        An owned descriptor for a regular file.
+
+    Raises:
+        ValueError: If the opened child is not a regular file.
+    """
+    descriptor = _open_child(
+        parent_descriptor,
+        parent_path,
+        name,
+        flags
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0),
+    )
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError(error_message)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _open_child(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    flags: int,
+    mode: int = 0o777,
+) -> int:
+    """Open a child through its anchored parent when supported.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback parent path.
+        name: Child basename.
+        flags: Flags accepted by ``os.open``.
+        mode: Creation permissions when relevant.
+
+    Returns:
+        An owned file descriptor.
+    """
+    if parent_descriptor is None:
+        return os.open(parent_path / name, flags, mode)
+    return os.open(name, flags, mode, dir_fd=parent_descriptor)
+
+
+def _unlink_child(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+) -> None:
+    """Unlink a child through an anchored parent when supported.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback parent path.
+        name: Child basename.
+
+    Returns:
+        None.
+    """
+    if parent_descriptor is None:
+        os.unlink(parent_path / name)
+    else:
+        os.unlink(name, dir_fd=parent_descriptor)
+
+
+def _link_children(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    source: str,
+    destination: str,
+) -> None:
+    """Publish a child with atomic no-replace semantics.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback parent path.
+        source: Existing temporary basename.
+        destination: New destination basename.
+
+    Returns:
+        None.
+    """
+    if parent_descriptor is None:
+        os.link(parent_path / source, parent_path / destination)
+    else:
+        os.link(
+            source,
+            destination,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+
+
+def _replace_child(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    source: str,
+    destination: str,
+) -> None:
+    """Atomically replace one sibling with another.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback parent path.
+        source: Existing temporary basename.
+        destination: Destination basename.
+
+    Returns:
+        None.
+    """
+    if parent_descriptor is None:
+        os.replace(parent_path / source, parent_path / destination)
+    else:
+        os.replace(
+            source,
+            destination,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+
+
+def _fsync_parent(
+    parent_descriptor: int | None,
+    parent_path: Path,
+) -> None:
+    """Persist directory entries when the platform supports it.
+
+    Args:
+        parent_descriptor: Anchored directory descriptor or ``None``.
+        parent_path: Canonical fallback directory path.
+
+    Returns:
+        None.
+    """
+    if parent_descriptor is not None:
+        os.fsync(parent_descriptor)
+        return
+    if os.name == "nt":
+        return
+    descriptor = os.open(
+        parent_path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _connect_checkpoint(
+    checkpoint: Path,
+    *,
+    timeout: float = 0,
+):
+    """Open SQLite against a no-follow descriptor for the checkpoint inode.
+
+    Args:
+        checkpoint: Authorized checkpoint path.
+        timeout: SQLite lock wait in seconds.
+
+    Yields:
+        An open SQLite connection anchored to the verified checkpoint file.
+
+    Raises:
+        ValueError: If the checkpoint is not a regular file.
+    """
+    resolved, parent_descriptor = _open_authorized_parent(
+        checkpoint,
+        "job_path",
+        must_exist=True,
+    )
+    file_descriptor = None
+    connection = None
+    try:
+        file_descriptor = _open_regular_child(
+            parent_descriptor,
+            resolved.parent,
+            resolved.name,
+            os.O_RDWR,
+            f"job_path is not a readable checkpoint: {resolved}",
+        )
+        connection = _connect_descriptor_database(
+            file_descriptor,
+            timeout=timeout,
+        )
+        yield connection
+    finally:
+        if connection is not None:
+            connection.close()
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        if parent_descriptor is not None:
+            os.close(parent_descriptor)
+
+
+def _resolve_device(device: str, inherited_device: str | None = None) -> str:
+    """Resolve MCP convenience device values.
+
+    Args:
+        device: Configured device string.
+        inherited_device: Resolved segmenter device for ``inherit``.
+
+    Returns:
+        Concrete device string accepted by Hashformers.
+    """
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "inherit":
+        if inherited_device is None:
+            raise ValueError("inherit requires a resolved segmenter device")
+        return inherited_device
+    return device
 
 
 def get_segmenter() -> TransformerWordSegmenter:
-    """Return the process-wide Transformer word segmenter.
+    """Return the lazily initialized process-wide Transformer segmenter.
 
     Returns:
-        The segmenter reused by every MCP tool call in this process.
+        The segmenter reused by every Transformer-backed MCP tool call.
     """
     global _segmenter
     if _segmenter is None:
         with _segmenter_lock:
             if _segmenter is None:
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-                _segmenter = TransformerWordSegmenter(segmenter_device=device)
+                segmenter_device = _resolve_device(_server_config.segmenter_device)
+                reranker_device = _resolve_device(
+                    _server_config.reranker_device,
+                    inherited_device=segmenter_device,
+                )
+                _segmenter = TransformerWordSegmenter(
+                    segmenter_model_name_or_path=_server_config.segmenter_model,
+                    segmenter_model_type=_server_config.segmenter_model_type,
+                    segmenter_device=segmenter_device,
+                    segmenter_gpu_batch_size=_server_config.segmenter_batch_size,
+                    reranker_model_name_or_path=_server_config.reranker_model,
+                    reranker_model_type=_server_config.reranker_model_type,
+                    reranker_device=reranker_device,
+                    reranker_gpu_batch_size=_server_config.reranker_batch_size,
+                )
     return _segmenter
 
 
-def _ranked_candidates(
-    rank,
-    selected_segmentation: str,
-    top_k: int,
-) -> list[Candidate]:
-    """Serialize the top candidates for one hashtag.
+def _validate_positive(value: int, name: str) -> None:
+    """Validate a positive non-boolean integer.
 
     Args:
-        rank: Candidate ranking returned by Hashformers.
-        selected_segmentation: Selected segmentation returned by Hashformers.
-        top_k: Maximum number of candidates to return.
+        value: Value to validate.
+        name: Argument name used in an error message.
+
+    Raises:
+        ValueError: If the value is not a positive integer.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+def _validate_at_most(value: int, maximum: int, name: str) -> None:
+    """Validate a positive integer with a server-enforced upper bound.
+
+    Args:
+        value: Value to validate.
+        maximum: Largest accepted value.
+        name: Argument name used in an error message.
+
+    Raises:
+        ValueError: If the value is not positive or exceeds ``maximum``.
+    """
+    _validate_positive(value, name)
+    if value > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+
+
+def _validate_input_count(values: list, name: str) -> None:
+    """Keep interactive MCP requests within a fixed memory budget.
+
+    Args:
+        values: Caller-provided list.
+        name: Argument name used in an error message.
+
+    Raises:
+        ValueError: If the list exceeds the interactive request ceiling.
+    """
+    if len(values) > MAX_INTERACTIVE_INPUTS:
+        raise ValueError(
+            f"{name} accepts at most {MAX_INTERACTIVE_INPUTS} items; "
+            "use the resumable file-job tools for larger inputs"
+        )
+
+
+def _validate_max_candidates(max_candidates: int) -> None:
+    """Validate the response-size limit.
+
+    Args:
+        max_candidates: Candidate limit.
+
+    Raises:
+        ValueError: If the limit is invalid or exceeds the response ceiling.
+    """
+    _validate_at_most(
+        max_candidates,
+        MAX_RETURNED_CANDIDATES,
+        "max_candidates",
+    )
+
+
+def _validate_beam_work(inputs: list[str], top_k: int, steps: int) -> None:
+    """Reject beam-search requests with an excessive expansion upper bound.
+
+    Args:
+        inputs: Preprocessed strings passed to beam search.
+        top_k: Beam width retained after each step.
+        steps: Number of beam-search expansion steps.
+
+    Raises:
+        ValueError: If the request can exceed the process-wide work budget.
+    """
+    estimated_expansions = 0
+    for value in inputs:
+        length = len(value)
+        estimated_expansions += length
+        estimated_expansions += top_k * sum(
+            length + step for step in range(1, steps)
+        )
+        if estimated_expansions > MAX_BEAM_EXPANSIONS:
+            raise ValueError(
+                "beam-search request is too large; reduce the input batch, "
+                "top_k, or steps"
+            )
+
+
+def _validate_finite(value: float, name: str) -> None:
+    """Validate a finite numeric value.
+
+    Args:
+        value: Value to validate.
+        name: Argument name used in an error message.
+
+    Raises:
+        ValueError: If the value is boolean, nonnumeric, or non-finite.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a finite number")
+    if not math.isfinite(float(value)):
+        raise ValueError(f"{name} must be a finite number")
+
+
+def _validate_hashtag_character(hashtag_character: str) -> None:
+    """Validate a single-character hashtag marker.
+
+    Args:
+        hashtag_character: Marker used during preprocessing and replacement.
+
+    Raises:
+        ValueError: If the marker is not exactly one character.
+    """
+    if not isinstance(hashtag_character, str) or len(hashtag_character) != 1:
+        raise ValueError("hashtag_character must contain exactly one character")
+
+
+def _validate_strings(values: list[str], name: str) -> None:
+    """Validate a list whose elements must all be strings.
+
+    Args:
+        values: Values to validate.
+        name: Argument name used in an error message.
+
+    Raises:
+        ValueError: If any element is not a string.
+    """
+    if not isinstance(values, list) or any(
+        not isinstance(value, str) for value in values
+    ):
+        raise ValueError(f"{name} must be a list of strings")
+
+
+def _validate_regex_inputs(values: list[str]) -> None:
+    """Validate bounded text passed to the timeout-protected regex engine.
+
+    Args:
+        values: Text values to validate.
+
+    Raises:
+        ValueError: If an input exceeds the regex safety ceiling.
+    """
+    for value in values:
+        if len(value) > MAX_REGEX_INPUT_LENGTH:
+            raise ValueError(
+                f"regex inputs must contain at most {MAX_REGEX_INPUT_LENGTH} characters"
+            )
+
+
+def _validate_hashtag_lengths(values: list[str]) -> None:
+    """Prevent pathological beam trees from unbounded input strings.
+
+    Args:
+        values: Hashtags or unspaced words to validate.
+
+    Raises:
+        ValueError: If an input exceeds the hashtag-length ceiling.
+    """
+    for value in values:
+        if len(value) > MAX_HASHTAG_LENGTH:
+            raise ValueError(
+                f"hashtags must contain at most {MAX_HASHTAG_LENGTH} characters"
+            )
+
+
+def _compile_regex_rules(
+    regex_rules: list[str] | None,
+) -> list[timeout_regex.Pattern]:
+    """Compile a bounded rule set for timeout-protected substitution.
+
+    Args:
+        regex_rules: Ordered custom rules or ``None`` for the library default.
 
     Returns:
-        JSON-serializable candidate records ordered by score.
+        Compiled rules in caller order.
+
+    Raises:
+        ValueError: If the rule set exceeds MCP safety limits.
     """
-    characters = selected_segmentation.replace(" ", "")
+    rules = regex_rules if regex_rules is not None else [r"([A-Z]+)"]
+    _validate_strings(rules, "regex_rules")
+    if not rules:
+        raise ValueError("regex_rules must not be empty when provided")
+    if len(rules) > MAX_REGEX_RULES:
+        raise ValueError(f"regex_rules must contain at most {MAX_REGEX_RULES} rules")
+    for rule in rules:
+        if len(rule) > MAX_REGEX_PATTERN_LENGTH:
+            raise ValueError(
+                "regex rules must contain at most "
+                f"{MAX_REGEX_PATTERN_LENGTH} characters"
+            )
+    try:
+        return [timeout_regex.compile(rule) for rule in rules]
+    except timeout_regex.error as error:
+        raise ValueError(f"invalid regex rule: {error}") from error
+
+
+class _TimeoutRegexWordSegmenter(RegexWordSegmenter):
+    """Apply RegexWordSegmenter semantics with per-substitution timeouts.
+
+    """
+
+    def __init__(self, regex_rules: list[str] | None = None):
+        """Compile the configured ordered regex rules.
+
+        Args:
+            regex_rules: Ordered custom rules or ``None`` for the default.
+        """
+        self.regex_rules = _compile_regex_rules(regex_rules)
+
+    def segment_word(self, rule: timeout_regex.Pattern, word: str) -> str:
+        """Apply one segmentation rule within a fixed CPU-time budget.
+
+        Args:
+            rule: Compiled timeout-capable rule.
+            word: Current intermediate segmentation.
+
+        Returns:
+            Text after inserting the rule's captured word boundary.
+
+        Raises:
+            ValueError: If the rule times out or expands the intermediate too far.
+        """
+        try:
+            segmented = rule.sub(
+                r" \1",
+                word,
+                timeout=REGEX_TIMEOUT_SECONDS,
+            ).strip()
+        except TimeoutError as error:
+            raise ValueError("regex rule exceeded the execution timeout") from error
+        if len(segmented) > MAX_REGEX_OUTPUT_LENGTH:
+            raise ValueError("regex rules produced an oversized intermediate result")
+        return segmented
+
+
+def _normalize_inputs(
+    inputs: list[str],
+    lower: bool,
+    remove_hashtag: bool,
+    hashtag_character: str,
+) -> list[str]:
+    """Apply the preprocessing implemented by ``BaseSegmenter``.
+
+    Args:
+        inputs: Input strings to normalize.
+        lower: Whether to lowercase the inputs.
+        remove_hashtag: Whether to strip leading hashtag characters.
+        hashtag_character: Character stripped from the left edge.
+
+    Returns:
+        Normalized inputs in their original order.
+    """
+    normalized = []
+    for value in inputs:
+        if lower:
+            value = value.lower()
+        if remove_hashtag:
+            value = value.lstrip(hashtag_character)
+        normalized.append(value)
+    return normalized
+
+
+def _validate_runtime_options(
+    top_k: int,
+    steps: int,
+    alpha: float,
+    beta: float,
+    max_candidates: int,
+    hashtag_character: str,
+) -> None:
+    """Validate shared Transformer inference options.
+
+    Args:
+        top_k: Beam width.
+        steps: Beam-search depth.
+        alpha: Segmenter ensemble weight.
+        beta: Reranker ensemble weight.
+        max_candidates: Optional response-size limit.
+        hashtag_character: Preprocessing marker.
+
+    Raises:
+        ValueError: If an option is outside its supported domain.
+    """
+    _validate_at_most(top_k, MAX_TOP_K, "top_k")
+    _validate_at_most(steps, MAX_STEPS, "steps")
+    _validate_finite(alpha, "alpha")
+    _validate_finite(beta, "beta")
+    _validate_max_candidates(max_candidates)
+    _validate_hashtag_character(hashtag_character)
+
+
+def _resolve_ranking_strategy(strategy: RankingStrategy) -> ResolvedRankingStrategy:
+    """Resolve an explicit pipeline component for result selection.
+
+    Args:
+        strategy: Requested strategy or ``auto``.
+
+    Returns:
+        Concrete component used to select the result.
+
+    Raises:
+        ValueError: If the strategy is invalid or needs an absent reranker.
+    """
+    allowed = {"auto", "segmenter", "reranker", "ensemble"}
+    if strategy not in allowed:
+        raise ValueError(
+            "ranking_strategy must be auto, segmenter, reranker, or ensemble"
+        )
+    if strategy == "auto":
+        return "ensemble" if _server_config.reranker_model else "segmenter"
+    if strategy in {"reranker", "ensemble"} and not _server_config.reranker_model:
+        raise ValueError(
+            f"ranking_strategy={strategy} requires --reranker-model at server startup"
+        )
+    return strategy
+
+
+def _strategy_flags(
+    strategy: ResolvedRankingStrategy,
+) -> tuple[bool, bool]:
+    """Map a ranking strategy to library execution flags.
+
+    Args:
+        strategy: Concrete ranking component.
+
+    Returns:
+        A ``use_reranker``, ``use_ensembler`` pair.
+    """
+    return strategy != "segmenter", strategy == "ensemble"
+
+
+def _run_transformer_pipeline(
+    segmenter: TransformerWordSegmenter,
+    inputs: list[str],
+    top_k: int,
+    steps: int,
+    alpha: float,
+    beta: float,
+    strategy: ResolvedRankingStrategy,
+    preprocessing_kwargs: dict,
+    segmenter_run=None,
+) -> WordSegmenterOutput:
+    """Run every public ``BaseWordSegmenter`` option on the configured models.
+
+    Args:
+        segmenter: Process-wide configured Transformer segmenter.
+        inputs: Words or hashtags to segment or align with precomputed scores.
+        top_k: Beam width retained after each search step.
+        steps: Number of beam-search expansion steps.
+        alpha: Segmenter-score ensemble weight.
+        beta: Reranker-score ensemble weight.
+        strategy: Component used for final selection.
+        preprocessing_kwargs: Options forwarded to input preprocessing.
+        segmenter_run: Optional precomputed candidate scores.
+
+    Returns:
+        Selected segmentations and every component ranking that ran.
+    """
+    use_reranker, use_ensembler = _strategy_flags(strategy)
+    return BaseWordSegmenter.segment(
+        segmenter,
+        inputs,
+        segmenter_run=segmenter_run,
+        preprocessing_kwargs=preprocessing_kwargs,
+        segmenter_kwargs={"topk": top_k, "steps": steps},
+        ensembler_kwargs={"alpha": alpha, "beta": beta},
+        use_reranker=use_reranker,
+        use_ensembler=use_ensembler,
+        return_ranks=True,
+    )
+
+
+def _serialize_rank(
+    rank,
+    normalized_input: str,
+    max_candidates: int,
+) -> list[Candidate]:
+    """Serialize one component ranking for one input.
+
+    Args:
+        rank: Candidate ranking DataFrame returned by Hashformers.
+        normalized_input: Preprocessed input used to select matching rows.
+        max_candidates: Maximum rows to return.
+
+    Returns:
+        JSON-safe candidates ordered by ascending score.
+
+    Raises:
+        RuntimeError: If a model emits a non-finite score.
+    """
+    if rank is None:
+        return []
+    characters = normalized_input.replace(" ", "")
     rows = rank[rank["characters"] == characters]
-    rows = rows.sort_values("score").head(top_k)
-    return [
-        {
-            "segmentation": str(row.segmentation),
-            "score": float(row.score),
-        }
-        for row in rows.itertuples(index=False)
-    ]
+    rows = rows.sort_values(["score", "segmentation"], kind="stable")
+    rows = rows.head(max_candidates)
+    candidates = []
+    for position, row in enumerate(rows.itertuples(index=False), start=1):
+        score = float(row.score)
+        if not math.isfinite(score):
+            raise RuntimeError("Hashformers produced a non-finite candidate score")
+        candidates.append(
+            {
+                "segmentation": str(row.segmentation),
+                "score": score,
+                "rank": position,
+            }
+        )
+    return candidates
+
+
+def _selected_rank(output: WordSegmenterOutput, strategy: ResolvedRankingStrategy):
+    """Select the ranking table corresponding to the requested strategy.
+
+    Args:
+        output: Ranked Hashformers output.
+        strategy: Component that selected the result.
+
+    Returns:
+        The selected component ranking table.
+    """
+    if strategy == "ensemble":
+        return output.ensemble_rank
+    if strategy == "reranker":
+        return output.reranker_rank
+    return output.segmenter_rank
+
+
+def _serialize_word_output(
+    original_inputs: list[str],
+    normalized_inputs: list[str],
+    output: WordSegmenterOutput,
+    strategy: ResolvedRankingStrategy,
+    max_candidates: int,
+    include_component_rankings: bool,
+) -> list[SegmentationResult]:
+    """Serialize a ``WordSegmenterOutput`` for MCP.
+
+    Args:
+        original_inputs: Caller-provided inputs.
+        normalized_inputs: Inputs after preprocessing.
+        output: Ranked output from Hashformers.
+        strategy: Component that selected each result.
+        max_candidates: Maximum candidates returned per component.
+        include_component_rankings: Whether to include every component rank.
+
+    Returns:
+        Per-input JSON-safe segmentation results.
+
+    Raises:
+        RuntimeError: If a selected component produced no matching candidates.
+    """
+    if len(output.output) != len(original_inputs):
+        raise RuntimeError(
+            "Hashformers returned a different number of results than inputs"
+        )
+    selected_rank = _selected_rank(output, strategy)
+    results = []
+    for original, normalized, selected in zip(
+        original_inputs,
+        normalized_inputs,
+        output.output,
+    ):
+        candidates = _serialize_rank(selected_rank, normalized, max_candidates)
+        if not candidates:
+            raise RuntimeError(f"Hashformers produced no candidates for {original!r}")
+        component_rankings = None
+        if include_component_rankings:
+            component_rankings = {
+                "segmenter": _serialize_rank(
+                    output.segmenter_rank,
+                    normalized,
+                    max_candidates,
+                ),
+                "reranker": (
+                    _serialize_rank(output.reranker_rank, normalized, max_candidates)
+                    if output.reranker_rank is not None
+                    else None
+                ),
+                "ensemble": (
+                    _serialize_rank(output.ensemble_rank, normalized, max_candidates)
+                    if output.ensemble_rank is not None
+                    else None
+                ),
+            }
+        results.append(
+            {
+                "input": original,
+                "normalized_input": normalized,
+                "selected_segmentation": str(selected),
+                "ranking_strategy": strategy,
+                "candidates": candidates,
+                "component_rankings": component_rankings,
+            }
+        )
+    return results
+
+
+def _regex_result(
+    original_input: str,
+    normalized_input: str,
+    segmentation: str,
+) -> SegmentationResult:
+    """Build a segmentation result for a deterministic regex output.
+
+    Args:
+        original_input: Text before preprocessing.
+        normalized_input: Text after preprocessing.
+        segmentation: Regex segmentation.
+
+    Returns:
+        A result compatible with Transformer hashtag results.
+    """
+    candidate: Candidate = {"segmentation": segmentation, "score": 0.0, "rank": 1}
+    return {
+        "input": original_input,
+        "normalized_input": normalized_input,
+        "selected_segmentation": segmentation,
+        "ranking_strategy": "segmenter",
+        "candidates": [candidate],
+        "component_rankings": None,
+    }
+
+
+def _resolve_input_format(
+    input_path: Path,
+    input_format: FileInputFormat,
+) -> Literal["text", "csv", "jsonl"]:
+    """Resolve automatic file-format selection from a filename suffix.
+
+    Args:
+        input_path: File to inspect by name.
+        input_format: Explicit format or ``auto``.
+
+    Returns:
+        Concrete supported input format.
+
+    Raises:
+        ValueError: If the format is unsupported.
+    """
+    allowed = {"auto", "text", "csv", "jsonl"}
+    if input_format not in allowed:
+        raise ValueError("input_format must be auto, text, csv, or jsonl")
+    if input_format != "auto":
+        return input_format
+    suffix = input_path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix in {".jsonl", ".ndjson"}:
+        return "jsonl"
+    return "text"
+
+
+class _BoundedTextLines:
+    """Iterate over bounded physical and logical text-file records.
+
+    Args:
+        file_object: Open text stream consumed one physical line at a time.
+    """
+
+    def __init__(self, file_object: TextIO):
+        """Initialize a bounded line iterator.
+
+        Args:
+            file_object: Open text stream to consume.
+        """
+        self.file_object = file_object
+        self.record_chars = 0
+
+    def __iter__(self):
+        """Return the iterator itself.
+
+        Returns:
+            This bounded line iterator.
+        """
+        return self
+
+    def __next__(self) -> str:
+        """Read one bounded physical line.
+
+        Returns:
+            The next physical line from the input stream.
+
+        Raises:
+            ValueError: If a physical or logical record exceeds the ceiling.
+            StopIteration: If the input stream is exhausted.
+        """
+        line = self.file_object.readline(MAX_FILE_RECORD_CHARS + 1)
+        if not line:
+            raise StopIteration
+        if len(line) > MAX_FILE_RECORD_CHARS:
+            raise ValueError(
+                f"file records must contain at most {MAX_FILE_RECORD_CHARS} "
+                "characters"
+            )
+        self.record_chars += len(line)
+        if self.record_chars > MAX_FILE_RECORD_CHARS:
+            raise ValueError(
+                f"file records must contain at most {MAX_FILE_RECORD_CHARS} "
+                "characters"
+            )
+        return line
+
+    def reset_record(self) -> None:
+        """Start accounting for the next logical record.
+
+        Returns:
+            None.
+        """
+        self.record_chars = 0
+
+
+def _iter_file_hashtags(
+    input_source: Path | TextIO,
+    input_format: Literal["text", "csv", "jsonl"],
+    input_field: str,
+) -> Iterator[tuple[int, str]]:
+    """Stream hashtags from text, CSV, or JSON Lines input.
+
+    Args:
+        input_source: UTF-8 path or already-open text stream.
+        input_format: Concrete file format.
+        input_field: Object or CSV column containing each hashtag.
+
+    Yields:
+        Source line numbers and hashtags in file order.
+
+    Raises:
+        ValueError: If a record is blank, malformed, or lacks ``input_field``.
+    """
+    if isinstance(input_source, Path):
+        with input_source.open("r", encoding="utf-8", newline="") as input_file:
+            yield from _iter_file_hashtags(input_file, input_format, input_field)
+        return
+
+    lines = _BoundedTextLines(input_source)
+    if input_format == "text":
+        for line_number, line in enumerate(lines, start=1):
+            lines.reset_record()
+            hashtag = line.rstrip("\r\n")
+            if not isinstance(hashtag, str) or not hashtag.strip():
+                raise ValueError(f"blank hashtag at line {line_number}")
+            yield line_number, hashtag
+        return
+
+    if input_format == "csv":
+        reader = csv.DictReader(lines)
+        if reader.fieldnames is None or input_field not in reader.fieldnames:
+            raise ValueError(f"CSV input must contain column {input_field!r}")
+        lines.reset_record()
+        for line_number, record in enumerate(reader, start=2):
+            lines.reset_record()
+            hashtag = record.get(input_field)
+            if not isinstance(hashtag, str) or not hashtag.strip():
+                raise ValueError(f"blank hashtag at CSV line {line_number}")
+            yield line_number, hashtag
+        return
+
+    for line_number, line in enumerate(lines, start=1):
+        lines.reset_record()
+        if not line.strip():
+            raise ValueError(f"blank JSON Lines record at line {line_number}")
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"invalid JSON Lines record at line {line_number}"
+            ) from error
+        if isinstance(record, str):
+            hashtag = record
+        elif isinstance(record, dict):
+            hashtag = record.get(input_field)
+        else:
+            hashtag = None
+        if not isinstance(hashtag, str) or not hashtag.strip():
+            raise ValueError(
+                f"JSON Lines record {line_number} must contain "
+                f"string field {input_field!r}"
+            )
+        yield line_number, hashtag
+
+
+def _hash_descriptor(descriptor: int) -> str:
+    """Calculate SHA-256 from an already-open regular file descriptor.
+
+    Args:
+        descriptor: Readable descriptor whose offset may be changed.
+
+    Returns:
+        Hexadecimal SHA-256 digest.
+    """
+    digest = hashlib.sha256()
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    for chunk in iter(lambda: os.read(descriptor, 1024 * 1024), b""):
+        digest.update(chunk)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    return digest.hexdigest()
+
+
+def _validate_job_schema(connection: sqlite3.Connection) -> None:
+    """Require the exact bounded tables created by Hashformers.
+
+    Args:
+        connection: Open candidate checkpoint database.
+
+    Returns:
+        None.
+
+    Raises:
+        ValueError: If any required table or constraint differs.
+    """
+    for table_name, expected in JOB_TABLE_SCHEMAS.items():
+        rows = connection.execute(f"PRAGMA table_info({table_name})").fetchall()
+        actual = tuple(
+            (name, column_type.upper(), not_null, primary_key)
+            for _, name, column_type, not_null, _, primary_key in rows
+        )
+        if actual != expected:
+            raise ValueError("job_path is not a valid Hashformers checkpoint")
+
+
+def _job_metadata(connection: sqlite3.Connection) -> dict[str, str]:
+    """Read all metadata from a file-job checkpoint.
+
+    Args:
+        connection: Open job database.
+
+    Returns:
+        Metadata keyed by field name.
+
+    Raises:
+        ValueError: If the database is not a bounded Hashformers checkpoint.
+    """
+    application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+    schema_version = connection.execute("PRAGMA user_version").fetchone()[0]
+    if (
+        application_id != JOB_APPLICATION_ID
+        or schema_version != JOB_SCHEMA_VERSION
+    ):
+        raise ValueError("job_path is not a valid Hashformers checkpoint")
+    _validate_job_schema(connection)
+    placeholders = ", ".join("?" for _ in JOB_METADATA_KEYS)
+    rows = connection.execute(
+        f"""
+        SELECT key, substr(value, 1, ?)
+        FROM metadata
+        WHERE key IN ({placeholders})
+        LIMIT ?
+        """,
+        (
+            MAX_JOB_METADATA_CHARS + 1,
+            *JOB_METADATA_KEYS,
+            len(JOB_METADATA_KEYS) + 1,
+        ),
+    ).fetchall()
+    if (
+        len(rows) != len(JOB_METADATA_KEYS)
+        or {key for key, _ in rows} != set(JOB_METADATA_KEYS)
+        or any(
+            not isinstance(key, str)
+            or not isinstance(value, str)
+            or len(value) > MAX_JOB_METADATA_CHARS
+            for key, value in rows
+        )
+    ):
+        raise ValueError("job checkpoint metadata is invalid or oversized")
+    return dict(rows)
+
+
+def _job_counts(connection: sqlite3.Connection) -> tuple[int, int, int]:
+    """Count source, unique, and completed records in a job.
+
+    Args:
+        connection: Open job database.
+
+    Returns:
+        Total source records, unique inputs, and completed unique inputs.
+    """
+    total = connection.execute("SELECT COUNT(*) FROM source_records").fetchone()[0]
+    unique = connection.execute("SELECT COUNT(*) FROM unique_hashtags").fetchone()[0]
+    processed = connection.execute(
+        "SELECT COUNT(*) FROM unique_hashtags WHERE result_json IS NOT NULL"
+    ).fetchone()[0]
+    return total, unique, processed
+
+
+def _file_job_status(
+    connection: sqlite3.Connection,
+    job_path: Path,
+    processed_this_call: int = 0,
+) -> FileJobStatus:
+    """Build the compact MCP response for a file job.
+
+    Args:
+        connection: Open job database.
+        job_path: Persistent checkpoint path.
+        processed_this_call: Unique inputs completed by the current call.
+
+    Returns:
+        JSON-safe job progress and reproducibility metadata.
+    """
+    metadata = _job_metadata(connection)
+    total, unique, processed = _job_counts(connection)
+    remaining = unique - processed
+    server_config = json.loads(metadata["server_config"])
+    run_options = json.loads(metadata["run_options"])
+    return {
+        "job_path": str(job_path),
+        "input_path": metadata["input_path"],
+        "output_path": metadata["output_path"],
+        "input_format": metadata["input_format"],
+        "status": "completed" if remaining == 0 else "in_progress",
+        "total_hashtags": total,
+        "unique_hashtags": unique,
+        "deduplicated_hashtags": total - unique,
+        "processed_unique": processed,
+        "processed_this_call": processed_this_call,
+        "remaining_unique": remaining,
+        "segmenter_model": server_config["segmenter_model"],
+        "reranker_model": server_config["reranker_model"],
+        "ranking_strategy": run_options["ranking_strategy"],
+    }
+
+
+def _finalize_file_job(
+    connection: sqlite3.Connection,
+    destination: Path,
+    overwrite: bool,
+) -> None:
+    """Materialize checkpointed results in original source order.
+
+    Args:
+        connection: Completed job database.
+        destination: JSON Lines output path.
+        overwrite: Whether an existing destination may be replaced.
+
+    Returns:
+        None.
+
+    Raises:
+        ValueError: If output exists without overwrite authorization.
+    """
+    destination, parent_descriptor = _open_authorized_parent(
+        destination,
+        "output_path",
+        must_exist=False,
+    )
+    temporary_name = None
+    try:
+        temporary_name = (
+            f".{destination.name}.{secrets.token_hex(16)}.tmp"
+        )
+        temporary_descriptor = _open_child(
+            parent_descriptor,
+            destination.parent,
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(
+            temporary_descriptor,
+            "w",
+            encoding="utf-8",
+            newline="\n",
+        ) as output_file:
+            rows = connection.execute(
+                """
+                SELECT CASE
+                           WHEN typeof(source_records.source_line) = 'integer'
+                           THEN source_records.source_line
+                       END,
+                       substr(source_records.input, 1, ?),
+                       substr(unique_hashtags.result_json, 1, ?)
+                FROM source_records
+                JOIN unique_hashtags USING (normalized)
+                ORDER BY source_records.rowid
+                """,
+                (
+                    MAX_HASHTAG_LENGTH + 1,
+                    MAX_JOB_RESULT_CHARS + 1,
+                ),
+            )
+            for source_line, original_input, result_json in rows:
+                if (
+                    isinstance(source_line, bool)
+                    or not isinstance(source_line, int)
+                    or source_line < 1
+                ):
+                    raise ValueError(
+                        "job checkpoint contains an invalid source line"
+                    )
+                if (
+                    not isinstance(original_input, str)
+                    or len(original_input) > MAX_HASHTAG_LENGTH
+                ):
+                    raise ValueError(
+                        "job checkpoint contains an oversized source input"
+                    )
+                if (
+                    not isinstance(result_json, str)
+                    or len(result_json) > MAX_JOB_RESULT_CHARS
+                ):
+                    raise ValueError(
+                        "job checkpoint contains an oversized result record"
+                    )
+                record = json.loads(result_json)
+                record["input"] = original_input
+                output_file.write(
+                    json.dumps(
+                        {"source_line": source_line, **record},
+                        ensure_ascii=False,
+                        allow_nan=False,
+                    )
+                )
+                output_file.write("\n")
+            output_file.flush()
+            os.fsync(output_file.fileno())
+        if overwrite:
+            _replace_child(
+                parent_descriptor,
+                destination.parent,
+                temporary_name,
+                destination.name,
+            )
+            temporary_name = None
+        else:
+            try:
+                _link_children(
+                    parent_descriptor,
+                    destination.parent,
+                    temporary_name,
+                    destination.name,
+                )
+            except FileExistsError as error:
+                existing_descriptor = None
+                temporary_descriptor = None
+                try:
+                    existing_descriptor = _open_regular_child(
+                        parent_descriptor,
+                        destination.parent,
+                        destination.name,
+                        os.O_RDONLY,
+                        "output_path must be a regular file inside its "
+                        "configured root",
+                    )
+                    temporary_descriptor = _open_regular_child(
+                        parent_descriptor,
+                        destination.parent,
+                        temporary_name,
+                        os.O_RDONLY,
+                        "temporary output is not a regular file",
+                    )
+                    if _hash_descriptor(existing_descriptor) == _hash_descriptor(
+                        temporary_descriptor
+                    ):
+                        _unlink_child(
+                            parent_descriptor,
+                            destination.parent,
+                            temporary_name,
+                        )
+                        temporary_name = None
+                        _fsync_parent(parent_descriptor, destination.parent)
+                        return
+                except OSError as open_error:
+                    raise ValueError(
+                        "output_path must be a regular file inside its "
+                        "configured root"
+                    ) from open_error
+                finally:
+                    if existing_descriptor is not None:
+                        os.close(existing_descriptor)
+                    if temporary_descriptor is not None:
+                        os.close(temporary_descriptor)
+                if temporary_name is None:
+                    return
+                raise ValueError(
+                    "output_path contains different content and overwrite is "
+                    f"disabled: {destination}"
+                ) from error
+            _unlink_child(
+                parent_descriptor,
+                destination.parent,
+                temporary_name,
+            )
+            temporary_name = None
+        _fsync_parent(parent_descriptor, destination.parent)
+    finally:
+        if temporary_name is not None:
+            try:
+                _unlink_child(
+                    parent_descriptor,
+                    destination.parent,
+                    temporary_name,
+                )
+            except FileNotFoundError:
+                pass
+        if parent_descriptor is not None:
+            os.close(parent_descriptor)
 
 
 mcp = MCPServer(
     "hashformers",
-    description="Segment hashtags into words with Transformer language models.",
+    description=(
+        "Segment hashtags and tweets, apply regex segmentation, and rank "
+        "precomputed hypotheses with Hashformers."
+    ),
 )
 
 
-@mcp.tool()
+MODEL_READ_ANNOTATIONS = ToolAnnotations(
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
+)
+LOCAL_READ_ANNOTATIONS = ToolAnnotations(
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=False,
+)
+FILE_WRITE_ANNOTATIONS = ToolAnnotations(
+    read_only_hint=False,
+    destructive_hint=True,
+    idempotent_hint=False,
+    open_world_hint=False,
+)
+FILE_MODEL_WRITE_ANNOTATIONS = ToolAnnotations(
+    read_only_hint=False,
+    destructive_hint=True,
+    idempotent_hint=False,
+    open_world_hint=True,
+)
+
+
+@mcp.tool(annotations=MODEL_READ_ANNOTATIONS)
 def segment_hashtags(
     hashtags: list[str],
     top_k: int = 5,
-) -> SegmentHashtagsResult:
-    """Segment hashtags and return their ranked candidates.
+    steps: int = 5,
+    ranking_strategy: RankingStrategy = "auto",
+    alpha: float = 0.222,
+    beta: float = 0.111,
+    lower: bool = False,
+    remove_hashtag: bool = True,
+    hashtag_character: str = "#",
+    max_candidates: int = 5,
+    include_component_rankings: bool = False,
+) -> SegmentationsResult:
+    """Segment hashtags with every option exposed by the Transformer pipeline.
 
     Args:
-        hashtags: Hashtags to segment.
-        top_k: Maximum number of ranked candidates to return per hashtag.
+        hashtags: Hashtags or unspaced words to segment.
+        top_k: Beam width retained after each search step.
+        steps: Number of beam-search expansion steps.
+        ranking_strategy: Component used to select the final segmentation.
+        alpha: Segmenter-score weight used by the ensemble.
+        beta: Reranker-score weight used by the ensemble.
+        lower: Whether to lowercase inputs before segmentation.
+        remove_hashtag: Whether to strip leading hashtag characters.
+        hashtag_character: Character stripped during preprocessing.
+        max_candidates: Response limit per ranking, capped at 64.
+        include_component_rankings: Whether to return every component rank.
 
     Returns:
-        The selected segmentation and candidates ranked by ascending score for
-        each input. Lower scores rank higher.
+        Selected segmentations, final candidates, and optional component ranks.
 
     Raises:
-        ValueError: If ``top_k`` is not a positive integer or a hashtag has no
-            text to segment.
+        ValueError: If inputs or options are invalid.
     """
-    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 1:
-        raise ValueError("top_k must be a positive integer")
-    if any(
-        not isinstance(hashtag, str) or not hashtag.lstrip("#").strip()
-        for hashtag in hashtags
-    ):
-        raise ValueError("hashtags must contain text to segment")
+    _validate_strings(hashtags, "hashtags")
+    _validate_input_count(hashtags, "hashtags")
+    _validate_hashtag_lengths(hashtags)
+    _validate_runtime_options(
+        top_k,
+        steps,
+        alpha,
+        beta,
+        max_candidates,
+        hashtag_character,
+    )
+    strategy = _resolve_ranking_strategy(ranking_strategy)
+    normalized = _normalize_inputs(
+        hashtags,
+        lower=lower,
+        remove_hashtag=remove_hashtag,
+        hashtag_character=hashtag_character,
+    )
+    if any(not value.strip() for value in normalized):
+        raise ValueError("hashtags must contain text after preprocessing")
     if not hashtags:
         return {"results": []}
+    _validate_beam_work(normalized, top_k, steps)
 
-    output = get_segmenter().segment(
-        hashtags,
-        topk=top_k,
-        return_ranks=True,
+    with _inference_lock:
+        output = _run_transformer_pipeline(
+            get_segmenter(),
+            hashtags,
+            top_k=top_k,
+            steps=steps,
+            alpha=alpha,
+            beta=beta,
+            strategy=strategy,
+            preprocessing_kwargs={
+                "lower": lower,
+                "remove_hashtag": remove_hashtag,
+                "hashtag_character": hashtag_character,
+            },
+        )
+    return {
+        "results": _serialize_word_output(
+            hashtags,
+            normalized,
+            output,
+            strategy,
+            max_candidates,
+            include_component_rankings,
+        )
+    }
+
+
+@mcp.tool(annotations=FILE_WRITE_ANNOTATIONS)
+def start_hashtag_file_job(
+    input_path: str,
+    output_path: str | None = None,
+    input_format: FileInputFormat = "auto",
+    input_field: str = "hashtag",
+    overwrite: bool = False,
+    top_k: int = 5,
+    steps: int = 5,
+    ranking_strategy: RankingStrategy = "auto",
+    alpha: float = 0.222,
+    beta: float = 0.111,
+    lower: bool = False,
+    remove_hashtag: bool = True,
+    hashtag_character: str = "#",
+    max_candidates: int = 1,
+    include_component_rankings: bool = False,
+) -> FileJobStatus:
+    """Index and checkpoint a local hashtag file without model inference.
+
+    Args:
+        input_path: UTF-8 text, CSV, or JSON Lines file read by the server.
+        output_path: Final JSON Lines destination, or a derived sibling path.
+        input_format: Input format or ``auto`` for suffix-based detection.
+        input_field: CSV column or JSON object field containing hashtags.
+        overwrite: Whether an existing output may be atomically replaced.
+        top_k: Beam width retained after each search step.
+        steps: Number of beam-search expansion steps.
+        ranking_strategy: Component used to select final segmentations.
+        alpha: Segmenter-score weight used by the ensemble.
+        beta: Reranker-score weight used by the ensemble.
+        lower: Whether to lowercase inputs before segmentation.
+        remove_hashtag: Whether to strip leading hashtag characters.
+        hashtag_character: Character stripped during preprocessing.
+        max_candidates: Candidate limit written per result, capped at 64.
+        include_component_rankings: Whether to write every component rank.
+
+    Returns:
+        A persistent job path and compact progress counts.
+
+    Raises:
+        ValueError: If paths, records, or segmentation options are invalid.
+    """
+    if not isinstance(input_path, str) or not input_path.strip():
+        raise ValueError("input_path must contain text")
+    if output_path is not None and (
+        not isinstance(output_path, str) or not output_path.strip()
+    ):
+        raise ValueError("output_path must contain text or be null")
+    if not isinstance(input_field, str) or not input_field.strip():
+        raise ValueError("input_field must contain text")
+    if not isinstance(overwrite, bool):
+        raise ValueError("overwrite must be a boolean")
+    if overwrite and not _server_config.allow_file_overwrite:
+        raise ValueError(
+            "overwrite=true requires --allow-file-overwrite at server startup"
+        )
+    _validate_runtime_options(
+        top_k,
+        steps,
+        alpha,
+        beta,
+        max_candidates,
+        hashtag_character,
     )
-    rank = output.ensemble_rank
-    if rank is None:
-        rank = output.reranker_rank
-    if rank is None:
-        rank = output.segmenter_rank
+    resolved_strategy = _resolve_ranking_strategy(ranking_strategy)
 
+    source = _resolve_file_path(input_path, "input_path", must_exist=True)
+    if not source.is_file():
+        raise ValueError(f"input_path is not a readable file: {source}")
+    resolved_format = _resolve_input_format(source, input_format)
+    destination = (
+        _resolve_file_path(output_path, "output_path", must_exist=False)
+        if output_path is not None
+        else source.with_name(f"{source.name}.hashformers.jsonl")
+    )
+    job_path = _resolve_file_path(
+        f"{destination}.job.sqlite3",
+        "job_path",
+        must_exist=False,
+    )
+    if source in {destination, job_path}:
+        raise ValueError("input, output, and job paths must be different")
+    if not destination.parent.is_dir():
+        raise ValueError(f"output directory does not exist: {destination.parent}")
+    if destination.exists() and not overwrite:
+        raise ValueError(
+            "output_path already exists; pass overwrite=true to replace it: "
+            f"{destination}"
+        )
+    if job_path.exists():
+        raise ValueError(
+            f"job checkpoint already exists; continue it instead: {job_path}"
+        )
+
+    run_options = {
+        "top_k": top_k,
+        "steps": steps,
+        "ranking_strategy": resolved_strategy,
+        "alpha": float(alpha),
+        "beta": float(beta),
+        "lower": lower,
+        "remove_hashtag": remove_hashtag,
+        "hashtag_character": hashtag_character,
+        "max_candidates": max_candidates,
+        "include_component_rankings": include_component_rankings,
+    }
+    source_descriptor = None
+    source_parent_descriptor = None
+    job_parent_descriptor = None
+    temporary_descriptor = None
+    temporary_name = None
+    connection = None
+    try:
+        source, source_parent_descriptor = _open_authorized_parent(
+            source,
+            "input_path",
+            must_exist=True,
+        )
+        source_descriptor = _open_regular_child(
+            source_parent_descriptor,
+            source.parent,
+            source.name,
+            os.O_RDONLY,
+            f"input_path is not a readable file: {source}",
+        )
+        initial_hash = _hash_descriptor(source_descriptor)
+
+        job_path, job_parent_descriptor = _open_authorized_parent(
+            job_path,
+            "job_path",
+            must_exist=False,
+        )
+        temporary_name = f".{job_path.name}.{secrets.token_hex(16)}.tmp"
+        temporary_descriptor = _open_child(
+            job_parent_descriptor,
+            job_path.parent,
+            temporary_name,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        connection = _connect_descriptor_database(temporary_descriptor)
+        connection.executescript(
+            f"""
+            PRAGMA application_id = {JOB_APPLICATION_ID};
+            PRAGMA user_version = {JOB_SCHEMA_VERSION};
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE source_records (
+                source_line INTEGER PRIMARY KEY,
+                input TEXT NOT NULL,
+                normalized TEXT NOT NULL
+            );
+            CREATE TABLE unique_hashtags (
+                normalized TEXT PRIMARY KEY,
+                representative_input TEXT NOT NULL,
+                result_json TEXT
+            );
+            """
+        )
+        metadata = {
+            "input_path": str(source),
+            "output_path": str(destination),
+            "input_format": resolved_format,
+            "input_field": input_field,
+            "input_hash": initial_hash,
+            "overwrite": json.dumps(overwrite),
+            "finalized": json.dumps(False),
+            "server_config": json.dumps(_model_config_payload(), sort_keys=True),
+            "run_options": json.dumps(run_options, sort_keys=True),
+        }
+        connection.executemany(
+            "INSERT INTO metadata(key, value) VALUES (?, ?)",
+            metadata.items(),
+        )
+        source_stream = os.fdopen(
+            os.dup(source_descriptor),
+            "r",
+            encoding="utf-8",
+            newline="",
+        )
+        with source_stream:
+            for source_line, hashtag in _iter_file_hashtags(
+                source_stream,
+                resolved_format,
+                input_field,
+            ):
+                _validate_hashtag_lengths([hashtag])
+                normalized = _normalize_inputs(
+                    [hashtag],
+                    lower=lower,
+                    remove_hashtag=remove_hashtag,
+                    hashtag_character=hashtag_character,
+                )[0]
+                if not normalized.strip():
+                    raise ValueError(
+                        f"hashtag at source line {source_line} has no text after "
+                        "preprocessing"
+                    )
+                _validate_beam_work([normalized], top_k, steps)
+                connection.execute(
+                    "INSERT INTO source_records VALUES (?, ?, ?)",
+                    (source_line, hashtag, normalized),
+                )
+                connection.execute(
+                    "INSERT OR IGNORE INTO unique_hashtags VALUES (?, ?, NULL)",
+                    (normalized, hashtag),
+                )
+        if _hash_descriptor(source_descriptor) != initial_hash:
+            raise ValueError("input file changed while the job was being indexed")
+        connection.commit()
+        connection.close()
+        connection = None
+        os.fsync(temporary_descriptor)
+        visible_temporary_descriptor = _open_regular_child(
+            job_parent_descriptor,
+            job_path.parent,
+            temporary_name,
+            os.O_RDONLY,
+            "temporary checkpoint is not a regular file",
+        )
+        try:
+            if not os.path.samestat(
+                os.fstat(temporary_descriptor),
+                os.fstat(visible_temporary_descriptor),
+            ):
+                raise ValueError("temporary checkpoint changed during indexing")
+        finally:
+            os.close(visible_temporary_descriptor)
+        try:
+            _link_children(
+                job_parent_descriptor,
+                job_path.parent,
+                temporary_name,
+                job_path.name,
+            )
+        except FileExistsError as error:
+            raise ValueError(
+                "job checkpoint was created concurrently; continue it instead: "
+                f"{job_path}"
+            ) from error
+        _unlink_child(
+            job_parent_descriptor,
+            job_path.parent,
+            temporary_name,
+        )
+        temporary_name = None
+        _fsync_parent(job_parent_descriptor, job_path.parent)
+
+        with _connect_checkpoint(job_path, timeout=0) as installed_connection:
+            status = _file_job_status(installed_connection, job_path)
+            if status["status"] == "completed":
+                _finalize_file_job(installed_connection, destination, overwrite)
+                installed_connection.execute(
+                    "UPDATE metadata SET value = ? WHERE key = 'finalized'",
+                    (json.dumps(True),),
+                )
+                installed_connection.commit()
+        return status
+    finally:
+        if connection is not None:
+            connection.close()
+        if temporary_descriptor is not None:
+            os.close(temporary_descriptor)
+        if temporary_name is not None:
+            try:
+                _unlink_child(
+                    job_parent_descriptor,
+                    job_path.parent,
+                    temporary_name,
+                )
+            except FileNotFoundError:
+                pass
+        if source_descriptor is not None:
+            os.close(source_descriptor)
+        if source_parent_descriptor is not None:
+            os.close(source_parent_descriptor)
+        if job_parent_descriptor is not None:
+            os.close(job_parent_descriptor)
+
+
+def _continue_file_job_sync(
+    checkpoint: Path,
+    max_unique_hashtags: int,
+) -> FileJobStatus:
+    """Claim, infer, persist, and finalize one file-job chunk in a worker.
+
+    Args:
+        checkpoint: Authorized SQLite checkpoint path.
+        max_unique_hashtags: Maximum unique inputs processed in this chunk.
+
+    Returns:
+        Updated persistent job status.
+
+    Raises:
+        ValueError: If the checkpoint is invalid, busy, or incompatible.
+    """
+    connection_manager = _connect_checkpoint(checkpoint, timeout=0)
+    connection = connection_manager.__enter__()
+    try:
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as error:
+            if "locked" in str(error).lower() or "busy" in str(error).lower():
+                raise ValueError("job is already being processed") from error
+            raise
+        try:
+            metadata = _job_metadata(connection)
+        except sqlite3.DatabaseError as error:
+            raise ValueError(
+                "job_path is not a valid Hashformers checkpoint"
+            ) from error
+        required_metadata = set(JOB_METADATA_KEYS)
+        if not required_metadata.issubset(metadata):
+            raise ValueError("job_path is not a valid Hashformers checkpoint")
+        _resolve_file_path(metadata["input_path"], "input_path", must_exist=False)
+        destination = _resolve_file_path(
+            metadata["output_path"],
+            "output_path",
+            must_exist=False,
+        )
+        overwrite = json.loads(metadata["overwrite"])
+        if not isinstance(overwrite, bool):
+            raise ValueError("job checkpoint contains an invalid overwrite policy")
+        if overwrite and not _server_config.allow_file_overwrite:
+            raise ValueError(
+                "job requires --allow-file-overwrite at server startup"
+            )
+        active_config = json.dumps(_model_config_payload(), sort_keys=True)
+        if active_config != metadata["server_config"]:
+            raise ValueError(
+                "MCP model configuration changed since the job was started"
+            )
+        run_options = json.loads(metadata["run_options"])
+        pending_rows = connection.execute(
+            """
+            SELECT substr(normalized, 1, ?),
+                   substr(representative_input, 1, ?)
+            FROM unique_hashtags
+            WHERE result_json IS NULL
+            ORDER BY rowid
+            LIMIT ?
+            """,
+            (
+                MAX_HASHTAG_LENGTH + 1,
+                MAX_HASHTAG_LENGTH + 1,
+                max_unique_hashtags,
+            ),
+        ).fetchall()
+        if any(
+            not isinstance(normalized, str)
+            or not isinstance(representative, str)
+            or len(normalized) > MAX_HASHTAG_LENGTH
+            or len(representative) > MAX_HASHTAG_LENGTH
+            for normalized, representative in pending_rows
+        ):
+            raise ValueError("job checkpoint contains an oversized hashtag")
+        pending = pending_rows
+        if pending:
+            representatives = [representative for _, representative in pending]
+            result = segment_hashtags(representatives, **run_options)
+            records_by_normalized = {
+                record["normalized_input"]: record for record in result["results"]
+            }
+            for normalized, _ in pending:
+                if normalized not in records_by_normalized:
+                    raise RuntimeError(
+                        f"Hashformers produced no result for {normalized!r}"
+                    )
+                connection.execute(
+                    "UPDATE unique_hashtags SET result_json = ? WHERE normalized = ?",
+                    (
+                        json.dumps(
+                            records_by_normalized[normalized],
+                            ensure_ascii=False,
+                            allow_nan=False,
+                        ),
+                        normalized,
+                    ),
+                )
+
+        # Make model results durable before publishing the final output. A
+        # retry can then finish or reconcile publication without rerunning it.
+        connection.commit()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as error:
+            if "locked" in str(error).lower() or "busy" in str(error).lower():
+                raise ValueError("job is already being processed") from error
+            raise
+        metadata = _job_metadata(connection)
+        status = _file_job_status(
+            connection,
+            checkpoint,
+            processed_this_call=len(pending),
+        )
+        if status["status"] == "completed" and not json.loads(metadata["finalized"]):
+            _finalize_file_job(connection, destination, overwrite)
+            try:
+                connection.execute(
+                    "UPDATE metadata SET value = ? WHERE key = 'finalized'",
+                    (json.dumps(True),),
+                )
+                connection.commit()
+            except sqlite3.OperationalError as error:
+                raise ValueError(
+                    "job checkpoint directory changed during processing"
+                ) from error
+        else:
+            connection.commit()
+        return status
+    finally:
+        connection_manager.__exit__(None, None, None)
+
+
+@mcp.tool(annotations=FILE_MODEL_WRITE_ANNOTATIONS)
+async def continue_hashtag_file_job(
+    job_path: str,
+    max_unique_hashtags: int = 64,
+    context: Context | None = None,
+) -> FileJobStatus:
+    """Process one resumable, bounded chunk of a hashtag file job.
+
+    Args:
+        job_path: Checkpoint returned by ``start_hashtag_file_job``.
+        max_unique_hashtags: Maximum unique hashtags inferred in this call.
+        context: MCP request context used for progress and cancellation.
+
+    Returns:
+        Updated progress; repeat until ``status`` is ``completed``.
+
+    Raises:
+        ValueError: If the checkpoint, input, or active model configuration changed.
+    """
+    if not isinstance(job_path, str) or not job_path.strip():
+        raise ValueError("job_path must contain text")
+    _validate_at_most(
+        max_unique_hashtags,
+        MAX_FILE_UNIQUE_HASHTAGS,
+        "max_unique_hashtags",
+    )
+    checkpoint = _resolve_file_path(job_path, "job_path", must_exist=True)
+    if not checkpoint.is_file():
+        raise ValueError(f"job_path is not a readable checkpoint: {checkpoint}")
+
+    if context is not None:
+        try:
+            with _connect_checkpoint(checkpoint, timeout=5) as connection:
+                _job_metadata(connection)
+                _, total_unique, processed_before = _job_counts(connection)
+        except sqlite3.DatabaseError as error:
+            raise ValueError(
+                "job_path is not a valid Hashformers checkpoint"
+            ) from error
+        await context.report_progress(
+            processed_before,
+            total_unique,
+            "Continuing Hashformers file segmentation",
+        )
+    status = await anyio.to_thread.run_sync(
+        lambda: _continue_file_job_sync(checkpoint, max_unique_hashtags),
+        abandon_on_cancel=False,
+    )
+    if context is not None:
+        await context.report_progress(
+            status["processed_unique"],
+            status["unique_hashtags"],
+            f"Checkpointed {status['processed_unique']} unique hashtags",
+        )
+    return status
+
+
+@mcp.tool(annotations=LOCAL_READ_ANNOTATIONS)
+def segment_with_regex(
+    inputs: list[str],
+    regex_rules: list[str] | None = None,
+    lower: bool = False,
+    remove_hashtag: bool = True,
+    hashtag_character: str = "#",
+) -> RegexSegmentationsResult:
+    """Segment text by applying regular-expression rules sequentially.
+
+    Args:
+        inputs: Texts to segment.
+        regex_rules: Ordered rules, or ``None`` for the library default.
+        lower: Whether to lowercase inputs before applying rules.
+        remove_hashtag: Whether to strip leading hashtag characters.
+        hashtag_character: Character stripped during preprocessing.
+
+    Returns:
+        Deterministic regex segmentations in input order.
+
+    Raises:
+        ValueError: If inputs, rules, or preprocessing options are invalid.
+    """
+    _validate_strings(inputs, "inputs")
+    _validate_input_count(inputs, "inputs")
+    _validate_regex_inputs(inputs)
+    _validate_hashtag_character(hashtag_character)
+    normalized = _normalize_inputs(
+        inputs,
+        lower=lower,
+        remove_hashtag=remove_hashtag,
+        hashtag_character=hashtag_character,
+    )
+    segmenter = _TimeoutRegexWordSegmenter(regex_rules=regex_rules)
+    segmentations = segmenter.segment(
+        inputs,
+        lower=lower,
+        remove_hashtag=remove_hashtag,
+        hashtag_character=hashtag_character,
+    )
     return {
         "results": [
             {
-                "input": hashtag,
-                "selected_segmentation": str(segmentation),
-                "candidates": _ranked_candidates(rank, str(segmentation), top_k),
+                "input": original,
+                "normalized_input": normalized_input,
+                "segmentation": segmentation,
             }
-            for hashtag, segmentation in zip(hashtags, output.output)
+            for original, normalized_input, segmentation in zip(
+                inputs,
+                normalized,
+                segmentations,
+            )
         ]
     }
 
 
-def main() -> None:
-    """Run the Hashformers MCP server over stdio.
+@mcp.tool(annotations=MODEL_READ_ANNOTATIONS)
+def segment_tweets(
+    tweets: list[str],
+    segmenter_kind: SegmenterKind = "regex",
+    regex_rules: list[str] | None = None,
+    top_k: int = 5,
+    steps: int = 5,
+    ranking_strategy: RankingStrategy = "auto",
+    alpha: float = 0.222,
+    beta: float = 0.111,
+    word_lower: bool = False,
+    max_candidates: int = 5,
+    include_component_rankings: bool = False,
+    hashtag_token: str | None = None,
+    lower: bool = False,
+    separator: str = " ",
+    hashtag_character: str = "#",
+    regex_flags: int = 0,
+) -> TweetSegmentationsResult:
+    """Extract and segment hashtags inside complete tweets.
+
+    Args:
+        tweets: Tweet texts to transform.
+        segmenter_kind: ``regex`` or the configured ``transformer`` pipeline.
+        regex_rules: Ordered rules used by the regex segmenter.
+        top_k: Transformer beam width.
+        steps: Transformer beam-search depth.
+        ranking_strategy: Transformer component used for final selection.
+        alpha: Segmenter-score weight used by the ensemble.
+        beta: Reranker-score weight used by the ensemble.
+        word_lower: Whether to lowercase hashtags before segmentation.
+        max_candidates: Transformer response limit, capped at 64.
+        include_component_rankings: Whether to include Transformer component ranks.
+        hashtag_token: Optional token prepended to each replacement.
+        lower: Whether to lowercase segmented hashtag replacements.
+        separator: Text placed between ``hashtag_token`` and a replacement.
+        hashtag_character: Character used to identify replacement keys.
+        regex_flags: Flags passed to Python regex replacement.
+
+    Returns:
+        Transformed tweets and per-occurrence hashtag segmentation details.
+
+    Raises:
+        ValueError: If inputs or selected-segmenter options are invalid.
+    """
+    _validate_strings(tweets, "tweets")
+    _validate_input_count(tweets, "tweets")
+    _validate_regex_inputs(tweets)
+    _validate_hashtag_character(hashtag_character)
+    if hashtag_character != "#":
+        raise ValueError("segment_tweets supports only hashtag_character='#'")
+    if segmenter_kind not in {"regex", "transformer"}:
+        raise ValueError("segmenter_kind must be regex or transformer")
+    if (
+        isinstance(regex_flags, bool)
+        or not isinstance(regex_flags, int)
+        or regex_flags < 0
+    ):
+        raise ValueError("regex_flags must be a non-negative integer")
+    if not isinstance(separator, str):
+        raise ValueError("separator must be a string")
+    if len(separator) > MAX_TWEET_REPLACEMENT_CHARS:
+        raise ValueError(
+            f"separator must contain at most {MAX_TWEET_REPLACEMENT_CHARS} "
+            "characters"
+        )
+    if hashtag_token is not None and not isinstance(hashtag_token, str):
+        raise ValueError("hashtag_token must be a string or null")
+    if (
+        hashtag_token is not None
+        and len(hashtag_token) > MAX_TWEET_REPLACEMENT_CHARS
+    ):
+        raise ValueError(
+            f"hashtag_token must contain at most {MAX_TWEET_REPLACEMENT_CHARS} "
+            "characters"
+        )
+    if segmenter_kind == "transformer" and regex_rules is not None:
+        raise ValueError("regex_rules are supported only with segmenter_kind='regex'")
+    if segmenter_kind == "regex":
+        _compile_regex_rules(regex_rules)
+    if segmenter_kind == "transformer":
+        _validate_runtime_options(
+            top_k,
+            steps,
+            alpha,
+            beta,
+            max_candidates,
+            hashtag_character,
+        )
+        strategy = _resolve_ranking_strategy(ranking_strategy)
+    else:
+        strategy = "segmenter"
+    if not tweets:
+        return {"results": []}
+
+    matcher = TwitterTextMatcher()
+    extracted_hashtags = matcher(tweets)
+    occurrence_count = sum(len(hashtags) for hashtags in extracted_hashtags)
+    if occurrence_count > MAX_TWEET_HASHTAG_OCCURRENCES:
+        raise ValueError(
+            "tweets must contain at most "
+            f"{MAX_TWEET_HASHTAG_OCCURRENCES} hashtag occurrences"
+        )
+    if not any(extracted_hashtags):
+        return {
+            "results": [
+                {"input": tweet, "segmented_text": tweet, "hashtags": []}
+                for tweet in tweets
+            ]
+        }
+
+    hashtag_set = list(
+        dict.fromkeys(
+            hashtag
+            for tweet_hashtags in extracted_hashtags
+            for hashtag in tweet_hashtags
+        )
+    )
+    _validate_input_count(hashtag_set, "unique tweet hashtags")
+    _validate_hashtag_lengths(hashtag_set)
+    normalized_hashtags = _normalize_inputs(
+        hashtag_set,
+        lower=word_lower,
+        remove_hashtag=True,
+        hashtag_character="#",
+    )
+    replacement_options = {
+        "hashtag_token": hashtag_token,
+        "lower": lower,
+        "separator": separator,
+        "hashtag_character": hashtag_character,
+    }
+    if segmenter_kind == "transformer":
+        _validate_beam_work(normalized_hashtags, top_k, steps)
+        word_segmenter = get_segmenter()
+        with _inference_lock:
+            word_output = _run_transformer_pipeline(
+                word_segmenter,
+                hashtag_set,
+                top_k=top_k,
+                steps=steps,
+                alpha=alpha,
+                beta=beta,
+                strategy=strategy,
+                preprocessing_kwargs={"lower": word_lower},
+            )
+    else:
+        word_segmenter = _TimeoutRegexWordSegmenter(regex_rules=regex_rules)
+        word_output = word_segmenter.predict(hashtag_set, lower=word_lower)
+
+    tweet_segmenter = TweetSegmenter(matcher=matcher, word_segmenter=word_segmenter)
+    container = HashtagContainer(
+        extracted_hashtags,
+        hashtag_set,
+        tweet_segmenter.compile_dict(
+            hashtag_set,
+            word_output.output,
+            **replacement_options,
+        )
+    )
+    segmented_tweets = list(
+        tweet_segmenter.segmented_tweet_generator(
+            tweets,
+            container.hashtags,
+            container.hashtag_set,
+            container.replacement_dict,
+            flag=regex_flags,
+        )
+    )
+    if sum(len(tweet) for tweet in segmented_tweets) > MAX_TWEET_OUTPUT_CHARS:
+        raise ValueError("tweet replacements produced an oversized response")
+
+    if segmenter_kind == "transformer":
+        unique_results = _serialize_word_output(
+            container.hashtag_set,
+            normalized_hashtags,
+            word_output,
+            strategy,
+            max_candidates,
+            include_component_rankings,
+        )
+    else:
+        unique_results = [
+            _regex_result(original, normalized, segmentation)
+            for original, normalized, segmentation in zip(
+                container.hashtag_set,
+                normalized_hashtags,
+                word_output.output,
+            )
+        ]
+    results_by_hashtag = {result["input"]: result for result in unique_results}
+    return {
+        "results": [
+            {
+                "input": tweet,
+                "segmented_text": segmented_tweet,
+                "hashtags": [results_by_hashtag[hashtag] for hashtag in hashtags],
+            }
+            for tweet, segmented_tweet, hashtags in zip(
+                tweets,
+                segmented_tweets,
+                container.hashtags,
+            )
+        ]
+    }
+
+
+@mcp.tool(annotations=MODEL_READ_ANNOTATIONS)
+def rank_candidates(
+    candidate_sets: list[CandidateSetInput],
+    ranking_strategy: RankingStrategy = "auto",
+    alpha: float = 0.222,
+    beta: float = 0.111,
+    max_candidates: int = 5,
+    include_component_rankings: bool = False,
+) -> SegmentationsResult:
+    """Select, rerank, or ensemble caller-supplied segmentation candidates.
+
+    Args:
+        candidate_sets: Precomputed hypotheses grouped by unsegmented input.
+        ranking_strategy: Component used to select each result.
+        alpha: Segmenter-score weight used by the ensemble.
+        beta: Reranker-score weight used by the ensemble.
+        max_candidates: Response limit per ranking, capped at 64.
+        include_component_rankings: Whether to return every component rank.
+
+    Returns:
+        Ranked candidate sets without rerunning beam search.
+
+    Raises:
+        ValueError: If candidate sets, scores, or ranking options are invalid.
+    """
+    if not isinstance(candidate_sets, list):
+        raise ValueError("candidate_sets must be a list")
+    _validate_input_count(candidate_sets, "candidate_sets")
+    _validate_finite(alpha, "alpha")
+    _validate_finite(beta, "beta")
+    _validate_max_candidates(max_candidates)
+    strategy = _resolve_ranking_strategy(ranking_strategy)
+
+    prepared = []
+    total_candidates = 0
+    for candidate_set in candidate_sets:
+        if not isinstance(candidate_set, dict):
+            raise ValueError("each candidate set must be an object")
+        original_input = candidate_set.get("input")
+        candidates = candidate_set.get("candidates")
+        if (
+            not isinstance(original_input, str)
+            or not original_input.lstrip("#").strip()
+        ):
+            raise ValueError("candidate set inputs must contain text")
+        _validate_hashtag_lengths([original_input])
+        if not isinstance(candidates, list) or not candidates:
+            raise ValueError("each candidate set must contain candidates")
+        total_candidates += len(candidates)
+        if total_candidates > MAX_PRECOMPUTED_CANDIDATES:
+            raise ValueError(
+                "candidate_sets must contain at most "
+                f"{MAX_PRECOMPUTED_CANDIDATES} total candidates"
+            )
+        normalized_input = original_input.lstrip("#")
+        expected_characters = normalized_input.replace(" ", "")
+        scores = {}
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                raise ValueError("each candidate must be an object")
+            segmentation = candidate.get("segmentation")
+            score = candidate.get("score")
+            if not isinstance(segmentation, str) or not segmentation.strip():
+                raise ValueError("candidate segmentations must contain text")
+            if segmentation != " ".join(segmentation.split()):
+                raise ValueError(
+                    "candidate segmentations must use single spaces as boundaries"
+                )
+            maximum_length = max(1, (2 * len(expected_characters)) - 1)
+            if len(segmentation) > maximum_length:
+                raise ValueError("candidate segmentation contains too many boundaries")
+            if segmentation in scores:
+                raise ValueError("candidate segmentations must be unique within a set")
+            if segmentation.replace(" ", "") != expected_characters:
+                raise ValueError(
+                    "candidate segmentations must match their unsegmented input"
+                )
+            _validate_finite(score, "candidate score")
+            scores[segmentation] = float(score)
+        prepared.append(
+            {
+                "index": len(prepared),
+                "original_input": original_input,
+                "normalized_input": normalized_input,
+                "characters": expected_characters,
+                "scores": scores,
+            }
+        )
+    if not prepared:
+        return {"results": []}
+
+    batches = []
+    batch_characters = []
+    for item in prepared:
+        for batch, characters in zip(batches, batch_characters):
+            if item["characters"] not in characters:
+                batch.append(item)
+                characters.add(item["characters"])
+                break
+        else:
+            batches.append([item])
+            batch_characters.append({item["characters"]})
+
+    results = [None] * len(prepared)
+
+    def process_batch(batch, segmenter=None) -> None:
+        """Rank one batch whose candidate character sets do not collide.
+
+        Args:
+            batch: Prepared candidate sets with distinct underlying characters.
+            segmenter: Configured Transformer wrapper for model-backed ranking.
+
+        Returns:
+            None.
+        """
+        combined_scores = {
+            segmentation: score
+            for item in batch
+            for segmentation, score in item["scores"].items()
+        }
+        combined_run = ProbabilityDictionary(combined_scores)
+        original_inputs = [item["original_input"] for item in batch]
+        normalized_inputs = [item["normalized_input"] for item in batch]
+        if strategy == "segmenter":
+            output = WordSegmenterOutput(
+                output=combined_run.get_segmentations(
+                    astype="list",
+                    gold_array=normalized_inputs,
+                ),
+                segmenter_rank=combined_run.to_dataframe(),
+            )
+        else:
+            output = _run_transformer_pipeline(
+                segmenter,
+                normalized_inputs,
+                top_k=5,
+                steps=5,
+                alpha=alpha,
+                beta=beta,
+                strategy=strategy,
+                segmenter_run=combined_run,
+                preprocessing_kwargs={"remove_hashtag": False},
+            )
+        serialized = _serialize_word_output(
+            original_inputs,
+            normalized_inputs,
+            output,
+            strategy,
+            max_candidates,
+            include_component_rankings,
+        )
+        for item, result in zip(batch, serialized):
+            results[item["index"]] = result
+
+    if strategy == "segmenter":
+        for batch in batches:
+            process_batch(batch)
+    else:
+        with _inference_lock:
+            segmenter = get_segmenter()
+            for batch in batches:
+                process_batch(batch, segmenter)
+    return {"results": results}
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Configure and run the Hashformers MCP server over stdio.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
 
     Returns:
         None.
     """
+    configure_server(parse_server_config(argv))
     mcp.run(transport="stdio")
 
 

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -1273,13 +1273,14 @@ def _compile_regex_rules(
     """Compile a bounded rule set for timeout-protected substitution.
 
     Args:
-        regex_rules: Ordered custom rules or ``None`` for the library default.
+        regex_rules: Ordered custom rules, each containing capture group 1, or
+            ``None`` for the library default.
 
     Returns:
         Compiled rules in caller order.
 
     Raises:
-        ValueError: If the rule set exceeds MCP safety limits.
+        ValueError: If the rules are invalid or exceed MCP safety limits.
     """
     rules = regex_rules if regex_rules is not None else [r"([A-Z]+)"]
     _validate_strings(rules, "regex_rules")
@@ -1294,9 +1295,12 @@ def _compile_regex_rules(
                 f"{MAX_REGEX_PATTERN_LENGTH} characters"
             )
     try:
-        return [timeout_regex.compile(rule) for rule in rules]
+        compiled_rules = [timeout_regex.compile(rule) for rule in rules]
     except timeout_regex.error as error:
         raise ValueError(f"invalid regex rule: {error}") from error
+    if any(rule.groups < 1 for rule in compiled_rules):
+        raise ValueError("each regex rule must contain at least one capturing group")
+    return compiled_rules
 
 
 class _TimeoutRegexWordSegmenter(RegexWordSegmenter):
@@ -1308,7 +1312,8 @@ class _TimeoutRegexWordSegmenter(RegexWordSegmenter):
         """Compile the configured ordered regex rules.
 
         Args:
-            regex_rules: Ordered custom rules or ``None`` for the default.
+            regex_rules: Ordered custom rules, each containing capture group
+                1, or ``None`` for the default.
         """
         self.regex_rules = _compile_regex_rules(regex_rules)
 
@@ -1479,6 +1484,7 @@ def _serialize_rank(
     rank,
     normalized_input: str,
     max_candidates: int,
+    selected_segmentation: str | None = None,
 ) -> list[Candidate]:
     """Serialize one component ranking for one input.
 
@@ -1486,18 +1492,37 @@ def _serialize_rank(
         rank: Candidate ranking DataFrame returned by Hashformers.
         normalized_input: Preprocessed input used to select matching rows.
         max_candidates: Maximum rows to return.
+        selected_segmentation: Selected hypothesis to place first within its
+            equal-score tier, or ``None`` for the ranking's stable order.
 
     Returns:
         JSON-safe candidates ordered by ascending score.
 
     Raises:
-        RuntimeError: If a model emits a non-finite score.
+        RuntimeError: If a model emits an invalid ranking or non-finite score.
     """
     if rank is None:
         return []
     characters = normalized_input.replace(" ", "")
     rows = rank[rank["characters"] == characters]
-    rows = rows.sort_values(["score", "segmentation"], kind="stable")
+    rows = rows.sort_values("score", kind="stable")
+    if selected_segmentation is not None and not rows.empty:
+        selected_rows = rows[rows["segmentation"] == selected_segmentation]
+        if selected_rows.empty:
+            raise RuntimeError(
+                "Hashformers selected a segmentation absent from its ranking"
+            )
+        if float(selected_rows.iloc[0]["score"]) != float(rows.iloc[0]["score"]):
+            raise RuntimeError(
+                "Hashformers selected a segmentation that is not top-ranked"
+            )
+        selected_index = selected_rows.index[0]
+        rows = rows.loc[
+            [
+                selected_index,
+                *[index for index in rows.index if index != selected_index],
+            ]
+        ]
     rows = rows.head(max_candidates)
     candidates = []
     for position, row in enumerate(rows.itertuples(index=False), start=1):
@@ -1566,7 +1591,13 @@ def _serialize_word_output(
         normalized_inputs,
         output.output,
     ):
-        candidates = _serialize_rank(selected_rank, normalized, max_candidates)
+        selected_segmentation = str(selected)
+        candidates = _serialize_rank(
+            selected_rank,
+            normalized,
+            max_candidates,
+            selected_segmentation=selected_segmentation,
+        )
         if not candidates:
             raise RuntimeError(f"Hashformers produced no candidates for {original!r}")
         component_rankings = None
@@ -1576,14 +1607,31 @@ def _serialize_word_output(
                     output.segmenter_rank,
                     normalized,
                     max_candidates,
+                    selected_segmentation=(
+                        selected_segmentation if strategy == "segmenter" else None
+                    ),
                 ),
                 "reranker": (
-                    _serialize_rank(output.reranker_rank, normalized, max_candidates)
+                    _serialize_rank(
+                        output.reranker_rank,
+                        normalized,
+                        max_candidates,
+                        selected_segmentation=(
+                            selected_segmentation if strategy == "reranker" else None
+                        ),
+                    )
                     if output.reranker_rank is not None
                     else None
                 ),
                 "ensemble": (
-                    _serialize_rank(output.ensemble_rank, normalized, max_candidates)
+                    _serialize_rank(
+                        output.ensemble_rank,
+                        normalized,
+                        max_candidates,
+                        selected_segmentation=(
+                            selected_segmentation if strategy == "ensemble" else None
+                        ),
+                    )
                     if output.ensemble_rank is not None
                     else None
                 ),
@@ -1592,7 +1640,7 @@ def _serialize_word_output(
             {
                 "input": original,
                 "normalized_input": normalized,
-                "selected_segmentation": str(selected),
+                "selected_segmentation": selected_segmentation,
                 "ranking_strategy": strategy,
                 "candidates": candidates,
                 "component_rankings": component_rankings,
@@ -1670,7 +1718,9 @@ class _BoundedTextLines:
             file_object: Open text stream to consume.
         """
         self.file_object = file_object
+        self.physical_line = 0
         self.record_chars = 0
+        self.record_start_line: int | None = None
 
     def __iter__(self):
         """Return the iterator itself.
@@ -1698,6 +1748,11 @@ class _BoundedTextLines:
                 f"file records must contain at most {MAX_FILE_RECORD_CHARS} "
                 "characters"
             )
+        self.physical_line += 1
+        if self.record_start_line is None:
+            if not line.rstrip("\r\n"):
+                return line
+            self.record_start_line = self.physical_line
         self.record_chars += len(line)
         if self.record_chars > MAX_FILE_RECORD_CHARS:
             raise ValueError(
@@ -1713,6 +1768,7 @@ class _BoundedTextLines:
             None.
         """
         self.record_chars = 0
+        self.record_start_line = None
 
 
 def _iter_file_hashtags(
@@ -1752,9 +1808,15 @@ def _iter_file_hashtags(
         reader = csv.DictReader(lines)
         if reader.fieldnames is None or input_field not in reader.fieldnames:
             raise ValueError(f"CSV input must contain column {input_field!r}")
-        lines.reset_record()
-        for line_number, record in enumerate(reader, start=2):
+        while True:
             lines.reset_record()
+            try:
+                record = next(reader)
+            except StopIteration:
+                break
+            line_number = lines.record_start_line
+            if line_number is None:
+                raise RuntimeError("CSV reader returned a record without a source line")
             hashtag = record.get(input_field)
             if not isinstance(hashtag, str) or not hashtag.strip():
                 raise ValueError(f"blank hashtag at CSV line {line_number}")
@@ -2295,10 +2357,14 @@ def start_hashtag_file_job(
     if not source.is_file():
         raise ValueError(f"input_path is not a readable file: {source}")
     resolved_format = _resolve_input_format(source, input_format)
-    destination = (
-        _resolve_file_path(output_path, "output_path", must_exist=False)
-        if output_path is not None
-        else source.with_name(f"{source.name}.hashformers.jsonl")
+    destination = _resolve_file_path(
+        (
+            output_path
+            if output_path is not None
+            else source.with_name(f"{source.name}.hashformers.jsonl")
+        ),
+        "output_path",
+        must_exist=False,
     )
     job_path = _resolve_file_path(
         f"{destination}.job.sqlite3",
@@ -2710,7 +2776,8 @@ def segment_with_regex(
 
     Args:
         inputs: Texts to segment.
-        regex_rules: Ordered rules, or ``None`` for the library default.
+        regex_rules: Ordered rules, each containing capture group 1, or
+            ``None`` for the library default.
         lower: Whether to lowercase inputs before applying rules.
         remove_hashtag: Whether to strip leading hashtag characters.
         hashtag_character: Character stripped during preprocessing.
@@ -2778,7 +2845,8 @@ def segment_tweets(
     Args:
         tweets: Tweet texts to transform.
         segmenter_kind: ``regex`` or the configured ``transformer`` pipeline.
-        regex_rules: Ordered rules used by the regex segmenter.
+        regex_rules: Ordered rules used by the regex segmenter; every rule must
+            contain capture group 1.
         top_k: Transformer beam width.
         steps: Transformer beam-search depth.
         ranking_strategy: Transformer component used for final selection.

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -1,0 +1,166 @@
+"""Expose Hashformers hashtag segmentation through a local MCP server.
+
+The module registers one structured tool and runs it over stdio for local MCP
+clients.
+"""
+
+from threading import Lock
+
+import torch
+from mcp.server import MCPServer
+from typing_extensions import TypedDict
+
+from hashformers.segmenter.auto import TransformerWordSegmenter
+
+
+class Candidate(TypedDict):
+    """Represent a ranked segmentation candidate.
+
+    Attributes:
+        segmentation: Candidate text with inferred word boundaries.
+        score: Language-model score; lower values rank higher.
+    """
+
+    segmentation: str
+    score: float
+
+
+class SegmentationResult(TypedDict):
+    """Represent the segmentation result for one input hashtag.
+
+    Attributes:
+        input: Original hashtag supplied by the caller.
+        selected_segmentation: Highest-ranked segmentation.
+        candidates: Ranked segmentation alternatives.
+    """
+
+    input: str
+    selected_segmentation: str
+    candidates: list[Candidate]
+
+
+class SegmentHashtagsResult(TypedDict):
+    """Represent the structured result returned by ``segment_hashtags``.
+
+    Attributes:
+        results: Per-input segmentation results in input order.
+    """
+
+    results: list[SegmentationResult]
+
+
+_segmenter: TransformerWordSegmenter | None = None
+_segmenter_lock = Lock()
+
+
+def get_segmenter() -> TransformerWordSegmenter:
+    """Return the process-wide Transformer word segmenter.
+
+    Returns:
+        The segmenter reused by every MCP tool call in this process.
+    """
+    global _segmenter
+    if _segmenter is None:
+        with _segmenter_lock:
+            if _segmenter is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                _segmenter = TransformerWordSegmenter(segmenter_device=device)
+    return _segmenter
+
+
+def _ranked_candidates(
+    rank,
+    selected_segmentation: str,
+    top_k: int,
+) -> list[Candidate]:
+    """Serialize the top candidates for one hashtag.
+
+    Args:
+        rank: Candidate ranking returned by Hashformers.
+        selected_segmentation: Selected segmentation returned by Hashformers.
+        top_k: Maximum number of candidates to return.
+
+    Returns:
+        JSON-serializable candidate records ordered by score.
+    """
+    characters = selected_segmentation.replace(" ", "")
+    rows = rank[rank["characters"] == characters]
+    rows = rows.sort_values("score").head(top_k)
+    return [
+        {
+            "segmentation": str(row.segmentation),
+            "score": float(row.score),
+        }
+        for row in rows.itertuples(index=False)
+    ]
+
+
+mcp = MCPServer(
+    "hashformers",
+    description="Segment hashtags into words with Transformer language models.",
+)
+
+
+@mcp.tool()
+def segment_hashtags(
+    hashtags: list[str],
+    top_k: int = 5,
+) -> SegmentHashtagsResult:
+    """Segment hashtags and return their ranked candidates.
+
+    Args:
+        hashtags: Hashtags to segment.
+        top_k: Maximum number of ranked candidates to return per hashtag.
+
+    Returns:
+        The selected segmentation and candidates ranked by ascending score for
+        each input. Lower scores rank higher.
+
+    Raises:
+        ValueError: If ``top_k`` is not a positive integer or a hashtag has no
+            text to segment.
+    """
+    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 1:
+        raise ValueError("top_k must be a positive integer")
+    if any(
+        not isinstance(hashtag, str) or not hashtag.lstrip("#").strip()
+        for hashtag in hashtags
+    ):
+        raise ValueError("hashtags must contain text to segment")
+    if not hashtags:
+        return {"results": []}
+
+    output = get_segmenter().segment(
+        hashtags,
+        topk=top_k,
+        return_ranks=True,
+    )
+    rank = output.ensemble_rank
+    if rank is None:
+        rank = output.reranker_rank
+    if rank is None:
+        rank = output.segmenter_rank
+
+    return {
+        "results": [
+            {
+                "input": hashtag,
+                "selected_segmentation": str(segmentation),
+                "candidates": _ranked_candidates(rank, str(segmentation), top_k),
+            }
+            for hashtag, segmentation in zip(hashtags, output.output)
+        ]
+    }
+
+
+def main() -> None:
+    """Run the Hashformers MCP server over stdio.
+
+    Returns:
+        None.
+    """
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,174 @@
+import asyncio
+import json
+from unittest.mock import create_autospec, patch
+
+import pandas as pd
+import pytest
+
+Client = pytest.importorskip("mcp").Client
+
+import hashformers.mcp_server as mcp_server
+from hashformers.segmenter.data_structures import WordSegmenterOutput
+from hashformers.mcp_server import get_segmenter, main, mcp, segment_hashtags
+
+
+@pytest.fixture(autouse=True)
+def clear_segmenter_cache():
+    """Clear the process-wide segmenter between tests.
+
+    Yields:
+        Control to the test with an empty segmenter cache.
+    """
+    mcp_server._segmenter = None
+    yield
+    mcp_server._segmenter = None
+
+
+def _mock_output() -> WordSegmenterOutput:
+    """Build a model-free segmentation result.
+
+    Returns:
+        A result containing two inputs and ranked candidates.
+    """
+    return WordSegmenterOutput(
+        output=["ice cold", "benfica memes"],
+        segmenter_rank=pd.DataFrame(
+            [
+                {
+                    "characters": "icecold",
+                    "segmentation": "icecold",
+                    "score": 3.0,
+                },
+                {
+                    "characters": "icecold",
+                    "segmentation": "i ce cold",
+                    "score": 2.0,
+                },
+                {
+                    "characters": "icecold",
+                    "segmentation": "ice cold",
+                    "score": 1.0,
+                },
+                {
+                    "characters": "benficamemes",
+                    "segmentation": "benfica memes",
+                    "score": 4.0,
+                },
+            ]
+        ),
+    )
+
+
+def test_segment_hashtags_returns_serializable_ranked_candidates():
+    segmenter = create_autospec(
+        mcp_server.TransformerWordSegmenter,
+        instance=True,
+    )
+    segmenter.segment.return_value = _mock_output()
+
+    with (
+        patch(
+            "hashformers.mcp_server.TransformerWordSegmenter",
+            return_value=segmenter,
+        ) as segmenter_class,
+        patch("hashformers.mcp_server.torch.cuda.is_available", return_value=False),
+    ):
+        result = segment_hashtags(["#icecold", "#benficamemes"], top_k=2)
+        segment_hashtags(["#icecold"], top_k=1)
+
+    assert result == {
+        "results": [
+            {
+                "input": "#icecold",
+                "selected_segmentation": "ice cold",
+                "candidates": [
+                    {"segmentation": "ice cold", "score": 1.0},
+                    {"segmentation": "i ce cold", "score": 2.0},
+                ],
+            },
+            {
+                "input": "#benficamemes",
+                "selected_segmentation": "benfica memes",
+                "candidates": [
+                    {"segmentation": "benfica memes", "score": 4.0},
+                ],
+            },
+        ]
+    }
+    json.dumps(result, allow_nan=False)
+    segmenter_class.assert_called_once_with(segmenter_device="cpu")
+    segmenter.segment.assert_any_call(
+        ["#icecold", "#benficamemes"],
+        topk=2,
+        return_ranks=True,
+    )
+
+
+def test_mcp_server_exposes_structured_segment_hashtags_tool():
+    segmenter = create_autospec(
+        mcp_server.TransformerWordSegmenter,
+        instance=True,
+    )
+    segmenter.segment.return_value = _mock_output()
+
+    async def call_tool():
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            result = await client.call_tool(
+                "segment_hashtags",
+                {"hashtags": ["#icecold"], "top_k": 1},
+            )
+            return tools, result
+
+    with patch(
+        "hashformers.mcp_server.TransformerWordSegmenter",
+        return_value=segmenter,
+    ):
+        tools, result = asyncio.run(call_tool())
+
+    assert [tool.name for tool in tools.tools] == ["segment_hashtags"]
+    assert tools.tools[0].input_schema["properties"]["top_k"]["default"] == 5
+    assert result.is_error is False
+    assert result.structured_content == {
+        "results": [
+            {
+                "input": "#icecold",
+                "selected_segmentation": "ice cold",
+                "candidates": [
+                    {"segmentation": "ice cold", "score": 1.0},
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("top_k", [0, -1, True, 1.5])
+def test_segment_hashtags_rejects_invalid_top_k_without_loading_model(top_k):
+    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
+        with pytest.raises(ValueError, match="top_k must be a positive integer"):
+            segment_hashtags(["#icecold"], top_k=top_k)
+
+    segmenter_class.assert_not_called()
+
+
+@pytest.mark.parametrize("hashtag", ["", "#", "###", "#   "])
+def test_segment_hashtags_rejects_blank_hashtags_without_loading_model(hashtag):
+    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
+        with pytest.raises(ValueError, match="hashtags must contain text"):
+            segment_hashtags([hashtag])
+
+    segmenter_class.assert_not_called()
+
+
+def test_segment_hashtags_handles_empty_input_without_loading_model():
+    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
+        assert segment_hashtags([]) == {"results": []}
+
+    segmenter_class.assert_not_called()
+
+
+def test_main_runs_server_over_stdio():
+    with patch.object(mcp, "run") as run:
+        main()
+
+    run.assert_called_once_with(transport="stdio")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -708,6 +708,43 @@ def test_start_hashtag_file_job_rejects_paths_outside_configured_roots(tmp_path)
         )
 
 
+@pytest.mark.parametrize(
+    ("target_exists", "overwrite"),
+    [(False, False), (True, True)],
+)
+def test_start_hashtag_file_job_authorizes_derived_output_symlink(
+    tmp_path,
+    target_exists,
+    overwrite,
+):
+    """Verify a derived destination cannot follow a symlink outside its root."""
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    input_path = allowed_root / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    outside_output = tmp_path / "outside.jsonl"
+    if target_exists:
+        outside_output.write_text("keep me", encoding="utf-8")
+    derived_output = allowed_root / "hashtags.txt.hashformers.jsonl"
+    derived_output.symlink_to(outside_output)
+    configure_server(
+        ServerConfig(file_roots=(str(allowed_root),), allow_file_overwrite=True)
+    )
+
+    with pytest.raises(ValueError, match="outside configured file roots"):
+        start_hashtag_file_job(
+            str(input_path),
+            overwrite=overwrite,
+            ranking_strategy="segmenter",
+        )
+
+    assert not list(allowed_root.glob("*.job.sqlite3"))
+    if target_exists:
+        assert outside_output.read_text(encoding="utf-8") == "keep me"
+    else:
+        assert not outside_output.exists()
+
+
 @requires_secure_file_jobs
 def test_file_job_rejects_replaced_configured_root(tmp_path):
     """Verify a same-path directory replacement does not inherit authority.
@@ -1376,6 +1413,31 @@ def test_file_reader_preserves_source_lines_across_formats(
     assert records == expected
 
 
+def test_csv_file_reader_preserves_physical_lines_for_multiline_records(tmp_path):
+    """Verify CSV source locations count embedded newlines physically."""
+    input_path = tmp_path / "hashtags.csv"
+    input_path.write_text(
+        'tag,label\n\n"#ice\ncold",a\n\n#mouraria,b\n',
+        encoding="utf-8",
+    )
+
+    records = list(mcp_server._iter_file_hashtags(input_path, "csv", "tag"))
+
+    assert records == [(3, "#ice\ncold"), (6, "#mouraria")]
+
+
+def test_csv_file_reader_reports_physical_line_after_blank_rows(tmp_path):
+    """Verify CSV validation errors identify a record's physical start."""
+    input_path = tmp_path / "hashtags.csv"
+    input_path.write_text(
+        "tag,label\n\n#icecold,a\n\n,b\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="blank hashtag at CSV line 5"):
+        list(mcp_server._iter_file_hashtags(input_path, "csv", "tag"))
+
+
 def test_segment_with_regex_exposes_rules_and_preprocessing():
     """Verify regex rules run sequentially through the MCP surface.
 
@@ -1407,6 +1469,12 @@ def test_segment_with_regex_rejects_invalid_rules():
     """
     with pytest.raises(ValueError, match="invalid regex rule"):
         segment_with_regex(["foo"], regex_rules=["("])
+
+
+def test_segment_with_regex_rejects_rules_without_capture_groups():
+    """Verify custom rules satisfy the segmenter's replacement contract."""
+    with pytest.raises(ValueError, match="at least one capturing group"):
+        segment_with_regex(["FOO"], regex_rules=[r"[A-Z]+"])
 
 
 def test_segment_with_regex_times_out_pathological_rules():
@@ -1518,6 +1586,62 @@ def test_rank_candidates_selects_precomputed_scores_without_loading_model():
     assert result["results"][0]["selected_segmentation"] == "ice cold"
     assert result["results"][0]["component_rankings"]["reranker"] is None
     get_model.assert_not_called()
+
+
+def test_rank_candidates_preserves_selected_tie_order():
+    """Verify serialized ties match ProbabilityDictionary selection order."""
+    candidate_sets = [
+        {
+            "input": "icecold",
+            "candidates": [
+                {"segmentation": "ice cold", "score": 1.0},
+                {"segmentation": "i ce cold", "score": 1.0},
+            ],
+        }
+    ]
+
+    result = rank_candidates(
+        candidate_sets,
+        ranking_strategy="segmenter",
+        max_candidates=1,
+    )
+
+    item = result["results"][0]
+    assert item["selected_segmentation"] == "ice cold"
+    assert item["candidates"] == [
+        {"segmentation": "ice cold", "score": 1.0, "rank": 1}
+    ]
+
+
+def test_rank_candidates_preserves_multi_input_tie_selections():
+    """Verify every selected tie is promoted before response truncation."""
+    result = rank_candidates(
+        [
+            {
+                "input": "aaaa",
+                "candidates": [
+                    {"segmentation": "aa aa", "score": 1.0},
+                    {"segmentation": "a aaa", "score": 1.0},
+                ],
+            },
+            {
+                "input": "bbbb",
+                "candidates": [
+                    {"segmentation": "bb bb", "score": 0.0},
+                    {"segmentation": "b bbb", "score": 0.0},
+                ],
+            },
+        ],
+        ranking_strategy="segmenter",
+        max_candidates=1,
+        include_component_rankings=True,
+    )
+
+    for item in result["results"]:
+        assert item["candidates"][0]["segmentation"] == item[
+            "selected_segmentation"
+        ]
+        assert item["component_rankings"]["segmenter"] == item["candidates"]
 
 
 def test_rank_candidates_passes_precomputed_run_to_reranker_pipeline():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,10 @@
 import asyncio
 import json
-from unittest.mock import create_autospec, patch
+import sqlite3
+import stat
+from pathlib import Path
+from threading import Event, get_ident
+from unittest.mock import AsyncMock, Mock, patch
 
 import pandas as pd
 import pytest
@@ -8,167 +12,1799 @@ import pytest
 Client = pytest.importorskip("mcp").Client
 
 import hashformers.mcp_server as mcp_server
+from hashformers.mcp_server import (
+    ServerConfig,
+    configure_server,
+    continue_hashtag_file_job,
+    get_segmenter,
+    main,
+    mcp,
+    parse_server_config,
+    rank_candidates,
+    segment_hashtags,
+    segment_tweets,
+    segment_with_regex,
+    start_hashtag_file_job,
+)
 from hashformers.segmenter.data_structures import WordSegmenterOutput
-from hashformers.mcp_server import get_segmenter, main, mcp, segment_hashtags
+
+requires_secure_file_jobs = pytest.mark.skipif(
+    not mcp_server.SUPPORTS_SECURE_FILE_JOBS,
+    reason="requires Linux descriptor-backed file operations",
+)
 
 
 @pytest.fixture(autouse=True)
-def clear_segmenter_cache():
-    """Clear the process-wide segmenter between tests.
+def reset_server_state(tmp_path):
+    """Reset process-wide MCP state between tests.
 
     Yields:
-        Control to the test with an empty segmenter cache.
+        Control to the test with default configuration and no loaded model.
     """
-    mcp_server._segmenter = None
+    configure_server(ServerConfig(file_roots=(str(tmp_path),)))
     yield
-    mcp_server._segmenter = None
+    configure_server(ServerConfig())
 
 
-def _mock_output() -> WordSegmenterOutput:
-    """Build a model-free segmentation result.
+def _rank(rows):
+    """Build a ranking DataFrame.
+
+    Args:
+        rows: ``segmentation``, ``score`` pairs for ``icecold``.
 
     Returns:
-        A result containing two inputs and ranked candidates.
+        A Hashformers-compatible ranking table.
     """
+    return pd.DataFrame(
+        [
+            {
+                "characters": segmentation.replace(" ", ""),
+                "segmentation": segmentation,
+                "score": score,
+            }
+            for segmentation, score in rows
+        ]
+    )
+
+
+def _mock_output(include_pipeline=False):
+    """Build a model-free ranked segmentation result.
+
+    Args:
+        include_pipeline: Whether to include reranker and ensemble ranks.
+
+    Returns:
+        Ranked output for one ``icecold`` input.
+    """
+    segmenter_rank = _rank([("ice cold", 1.0), ("i ce cold", 2.0), ("icecold", 3.0)])
+    if not include_pipeline:
+        return WordSegmenterOutput(
+            output=["ice cold"],
+            segmenter_rank=segmenter_rank,
+        )
     return WordSegmenterOutput(
-        output=["ice cold", "benfica memes"],
-        segmenter_rank=pd.DataFrame(
-            [
-                {
-                    "characters": "icecold",
-                    "segmentation": "icecold",
-                    "score": 3.0,
-                },
-                {
-                    "characters": "icecold",
-                    "segmentation": "i ce cold",
-                    "score": 2.0,
-                },
-                {
-                    "characters": "icecold",
-                    "segmentation": "ice cold",
-                    "score": 1.0,
-                },
-                {
-                    "characters": "benficamemes",
-                    "segmentation": "benfica memes",
-                    "score": 4.0,
-                },
-            ]
-        ),
+        output=["ice cold"],
+        segmenter_rank=segmenter_rank,
+        reranker_rank=_rank([("i ce cold", 0.5), ("ice cold", 1.5), ("icecold", 2.5)]),
+        ensemble_rank=_rank([("ice cold", 0.0), ("i ce cold", 1.0)]),
     )
 
 
-def test_segment_hashtags_returns_serializable_ranked_candidates():
-    segmenter = create_autospec(
-        mcp_server.TransformerWordSegmenter,
-        instance=True,
+def _mock_batch_output(_segmenter, inputs, **kwargs):
+    """Return each normalized input as its only segmentation.
+
+    Args:
+        _segmenter: Unused configured Transformer segmenter.
+        inputs: Hashtags supplied by an MCP tool.
+        **kwargs: Transformer pipeline options.
+
+    Returns:
+        Deterministic ranked output for the batch.
+    """
+    preprocessing = kwargs["preprocessing_kwargs"]
+    normalized = mcp_server._normalize_inputs(
+        inputs,
+        lower=preprocessing["lower"],
+        remove_hashtag=preprocessing["remove_hashtag"],
+        hashtag_character=preprocessing["hashtag_character"],
     )
-    segmenter.segment.return_value = _mock_output()
+    rank = pd.DataFrame(
+        [
+            {
+                "characters": value,
+                "segmentation": value,
+                "score": 1.0,
+            }
+            for value in normalized
+        ]
+    )
+    return WordSegmenterOutput(output=normalized, segmenter_rank=rank)
+
+
+def test_get_segmenter_forwards_complete_startup_configuration_once():
+    """Verify model identity and memory options configure the singleton.
+
+    """
+    configure_server(
+        ServerConfig(
+            segmenter_model="custom/gpt",
+            segmenter_model_type="incremental",
+            segmenter_device="cpu",
+            segmenter_batch_size=11,
+            reranker_model="custom/bert",
+            reranker_model_type="masked",
+            reranker_device="inherit",
+            reranker_batch_size=7,
+        )
+    )
+
+    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
+        first = get_segmenter()
+        second = get_segmenter()
+
+    assert first is second
+    segmenter_class.assert_called_once_with(
+        segmenter_model_name_or_path="custom/gpt",
+        segmenter_model_type="incremental",
+        segmenter_device="cpu",
+        segmenter_gpu_batch_size=11,
+        reranker_model_name_or_path="custom/bert",
+        reranker_model_type="masked",
+        reranker_device="cpu",
+        reranker_gpu_batch_size=7,
+    )
+
+
+def test_get_segmenter_resolves_auto_device_for_both_models():
+    """Verify auto and inherited devices resolve before model loading.
+
+    """
+    configure_server(ServerConfig(reranker_model="custom/bert"))
 
     with (
-        patch(
-            "hashformers.mcp_server.TransformerWordSegmenter",
-            return_value=segmenter,
-        ) as segmenter_class,
-        patch("hashformers.mcp_server.torch.cuda.is_available", return_value=False),
+        patch("hashformers.mcp_server.torch.cuda.is_available", return_value=True),
+        patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class,
     ):
-        result = segment_hashtags(["#icecold", "#benficamemes"], top_k=2)
-        segment_hashtags(["#icecold"], top_k=1)
+        get_segmenter()
 
-    assert result == {
-        "results": [
-            {
-                "input": "#icecold",
-                "selected_segmentation": "ice cold",
-                "candidates": [
-                    {"segmentation": "ice cold", "score": 1.0},
-                    {"segmentation": "i ce cold", "score": 2.0},
-                ],
-            },
-            {
-                "input": "#benficamemes",
-                "selected_segmentation": "benfica memes",
-                "candidates": [
-                    {"segmentation": "benfica memes", "score": 4.0},
-                ],
-            },
+    assert segmenter_class.call_args.kwargs["segmenter_device"] == "cuda"
+    assert segmenter_class.call_args.kwargs["reranker_device"] == "cuda"
+
+
+def test_parse_server_config_accepts_every_model_option():
+    """Verify every constructor-time capability is exposed by the CLI.
+
+    """
+    config = parse_server_config(
+        [
+            "--model",
+            "custom/gpt",
+            "--segmenter-model-type",
+            "incremental",
+            "--device",
+            "cpu",
+            "--batch-size",
+            "12",
+            "--reranker-model",
+            "custom/bert",
+            "--reranker-model-type",
+            "masked",
+            "--reranker-device",
+            "cuda",
+            "--reranker-batch-size",
+            "8",
         ]
+    )
+
+    assert config == ServerConfig(
+        segmenter_model="custom/gpt",
+        segmenter_model_type="incremental",
+        segmenter_device="cpu",
+        segmenter_batch_size=12,
+        reranker_model="custom/bert",
+        reranker_model_type="masked",
+        reranker_device="cuda",
+        reranker_batch_size=8,
+    )
+
+
+def test_parse_server_config_rejects_invalid_batch_size():
+    """Verify batch sizes cannot disable batching or become negative.
+
+    """
+    with pytest.raises(SystemExit):
+        parse_server_config(["--batch-size", "0"])
+
+
+def test_parse_server_config_accepts_file_policy(tmp_path):
+    """Verify file roots and destructive overwrite require startup policy.
+
+    """
+    config = parse_server_config(
+        [
+            "--file-root",
+            str(tmp_path),
+            "--allow-file-overwrite",
+        ]
+    )
+
+    assert config.file_roots == (str(tmp_path),)
+    assert config.allow_file_overwrite is True
+
+
+def test_run_transformer_pipeline_delegates_every_option_to_base_segmenter():
+    """Verify the compatibility helper forwards every library option exactly.
+
+    """
+    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter_run = object()
+    preprocessing_kwargs = {
+        "lower": True,
+        "remove_hashtag": False,
+        "hashtag_character": "!",
     }
-    json.dumps(result, allow_nan=False)
-    segmenter_class.assert_called_once_with(segmenter_device="cpu")
-    segmenter.segment.assert_any_call(
-        ["#icecold", "#benficamemes"],
-        topk=2,
+    expected = _mock_output()
+
+    with patch.object(
+        mcp_server.BaseWordSegmenter,
+        "segment",
+        return_value=expected,
+    ) as base_segment:
+        result = mcp_server._run_transformer_pipeline(
+            segmenter,
+            ["!IceCold"],
+            top_k=20,
+            steps=9,
+            alpha=0.4,
+            beta=0.6,
+            strategy="reranker",
+            preprocessing_kwargs=preprocessing_kwargs,
+            segmenter_run=segmenter_run,
+        )
+
+    assert result is expected
+    base_segment.assert_called_once_with(
+        segmenter,
+        ["!IceCold"],
+        segmenter_run=segmenter_run,
+        preprocessing_kwargs=preprocessing_kwargs,
+        segmenter_kwargs={"topk": 20, "steps": 9},
+        ensembler_kwargs={"alpha": 0.4, "beta": 0.6},
+        use_reranker=True,
+        use_ensembler=False,
         return_ranks=True,
     )
 
 
-def test_mcp_server_exposes_structured_segment_hashtags_tool():
-    segmenter = create_autospec(
-        mcp_server.TransformerWordSegmenter,
-        instance=True,
-    )
-    segmenter.segment.return_value = _mock_output()
+def test_segment_hashtags_separates_beam_width_from_response_limit():
+    """Verify asking for fewer results does not narrow beam search.
 
-    async def call_tool():
-        async with Client(mcp) as client:
-            tools = await client.list_tools()
-            result = await client.call_tool(
-                "segment_hashtags",
-                {"hashtags": ["#icecold"], "top_k": 1},
-            )
-            return tools, result
+    """
+    segmenter = mcp_server.BaseWordSegmenter()
+    pipeline = Mock(return_value=_mock_output())
 
-    with patch(
-        "hashformers.mcp_server.TransformerWordSegmenter",
-        return_value=segmenter,
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
-        tools, result = asyncio.run(call_tool())
+        result = segment_hashtags(
+            ["#IceCold"],
+            top_k=20,
+            steps=9,
+            ranking_strategy="segmenter",
+            lower=True,
+            max_candidates=2,
+        )
 
-    assert [tool.name for tool in tools.tools] == ["segment_hashtags"]
-    assert tools.tools[0].input_schema["properties"]["top_k"]["default"] == 5
-    assert result.is_error is False
-    assert result.structured_content == {
+    assert result == {
         "results": [
             {
-                "input": "#icecold",
+                "input": "#IceCold",
+                "normalized_input": "icecold",
                 "selected_segmentation": "ice cold",
+                "ranking_strategy": "segmenter",
                 "candidates": [
-                    {"segmentation": "ice cold", "score": 1.0},
+                    {"segmentation": "ice cold", "score": 1.0, "rank": 1},
+                    {"segmentation": "i ce cold", "score": 2.0, "rank": 2},
                 ],
+                "component_rankings": None,
             }
+        ]
+    }
+    pipeline.assert_called_once_with(
+        segmenter,
+        ["#IceCold"],
+        top_k=20,
+        steps=9,
+        alpha=0.222,
+        beta=0.111,
+        strategy="segmenter",
+        preprocessing_kwargs={
+            "lower": True,
+            "remove_hashtag": True,
+            "hashtag_character": "#",
+        },
+    )
+    json.dumps(result, allow_nan=False)
+
+
+def test_segment_hashtags_returns_all_component_rankings():
+    """Verify callers can inspect segmenter, reranker, and ensemble output.
+
+    """
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+    segmenter = mcp_server.BaseWordSegmenter()
+    pipeline = Mock(return_value=_mock_output(include_pipeline=True))
+
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = segment_hashtags(
+            ["#icecold"],
+            ranking_strategy="ensemble",
+            max_candidates=64,
+            include_component_rankings=True,
+        )
+
+    item = result["results"][0]
+    assert item["ranking_strategy"] == "ensemble"
+    assert [candidate["segmentation"] for candidate in item["candidates"]] == [
+        "ice cold",
+        "i ce cold",
+    ]
+    assert len(item["component_rankings"]["segmenter"]) == 3
+    assert len(item["component_rankings"]["reranker"]) == 3
+    assert len(item["component_rankings"]["ensemble"]) == 2
+    pipeline.assert_called_once_with(
+        segmenter,
+        ["#icecold"],
+        top_k=5,
+        steps=5,
+        alpha=0.222,
+        beta=0.111,
+        strategy="ensemble",
+        preprocessing_kwargs={
+            "lower": False,
+            "remove_hashtag": True,
+            "hashtag_character": "#",
+        },
+    )
+
+
+def test_auto_strategy_uses_reranker_only_when_configured():
+    """Verify auto preserves the Python pipeline's default selection.
+
+    """
+    segmenter = mcp_server.BaseWordSegmenter()
+    pipeline = Mock(return_value=_mock_output())
+
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = segment_hashtags(["#icecold"])
+
+    assert result["results"][0]["ranking_strategy"] == "segmenter"
+    assert pipeline.call_args.kwargs["strategy"] == "segmenter"
+
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+    pipeline.reset_mock()
+    pipeline.return_value = _mock_output(include_pipeline=True)
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = segment_hashtags(["#icecold"])
+
+    assert result["results"][0]["ranking_strategy"] == "ensemble"
+    assert pipeline.call_args.kwargs["strategy"] == "ensemble"
+
+
+@pytest.mark.parametrize("ranking_strategy", ["reranker", "ensemble"])
+def test_reranker_strategies_require_a_startup_model(ranking_strategy):
+    """Verify an unavailable pipeline component fails before model loading.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="requires --reranker-model"):
+            segment_hashtags(
+                ["#icecold"],
+                ranking_strategy=ranking_strategy,
+            )
+
+    get_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("argument", "value", "message"),
+    [
+        ("top_k", 0, "top_k must be a positive integer"),
+        ("top_k", 65, "top_k must be at most 64"),
+        ("steps", True, "steps must be a positive integer"),
+        ("steps", 33, "steps must be at most 32"),
+        ("max_candidates", -1, "max_candidates must be a positive integer"),
+        ("max_candidates", 65, "max_candidates must be at most 64"),
+        ("max_candidates", None, "max_candidates must be a positive integer"),
+        ("alpha", float("inf"), "alpha must be a finite number"),
+        ("hashtag_character", "##", "exactly one character"),
+    ],
+)
+def test_segment_hashtags_rejects_invalid_options_before_loading(
+    argument,
+    value,
+    message,
+):
+    """Verify invalid inference options cannot initialize a model.
+
+    """
+    options = {argument: value}
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match=message):
+            segment_hashtags(["#icecold"], **options)
+
+    get_model.assert_not_called()
+
+
+def test_segment_hashtags_rejects_oversized_interactive_batches():
+    """Verify large datasets are routed to bounded file-job calls.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="at most 64 items"):
+            segment_hashtags(["#tag"] * 65)
+
+    get_model.assert_not_called()
+
+
+def test_segment_hashtags_rejects_excessive_aggregate_beam_work():
+    """Verify individually valid options cannot combine into an OOM-scale run.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="beam-search request is too large"):
+            segment_hashtags(["a" * 512], top_k=64, steps=32)
+
+    get_model.assert_not_called()
+
+
+@pytest.mark.parametrize("hashtag", ["", "#", "###", "#   "])
+def test_segment_hashtags_rejects_blank_normalized_inputs(hashtag):
+    """Verify preprocessing cannot leave a content-free model input.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="after preprocessing"):
+            segment_hashtags([hashtag])
+
+    get_model.assert_not_called()
+
+
+def test_segment_hashtags_empty_input_does_not_load_model():
+    """Verify an empty batch returns immediately.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        assert segment_hashtags([]) == {"results": []}
+
+    get_model.assert_not_called()
+
+
+@requires_secure_file_jobs
+def test_hashtag_file_job_resumes_deduplicates_and_returns_only_summary(tmp_path):
+    """Verify bulk input is checkpointed and repeated work is avoided.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text(
+        "#icecold\n#benfica\n#icecold\n#mouraria\n#benfica\n",
+        encoding="utf-8",
+    )
+    segmenter = mcp_server.BaseWordSegmenter()
+    pipeline = Mock(side_effect=_mock_batch_output)
+    context = Mock()
+    context.report_progress = AsyncMock()
+
+    started = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    assert started["status"] == "in_progress"
+    assert started["processed_unique"] == 0
+    assert started["remaining_unique"] == 3
+    assert not Path(started["output_path"]).exists()
+
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        first = asyncio.run(
+            continue_hashtag_file_job(
+                started["job_path"],
+                max_unique_hashtags=2,
+                context=context,
+            )
+        )
+        summary = asyncio.run(
+            continue_hashtag_file_job(
+                started["job_path"],
+                max_unique_hashtags=2,
+                context=context,
+            )
+        )
+
+    assert first["status"] == "in_progress"
+    assert first["processed_this_call"] == 2
+    assert summary == {
+        "job_path": str(
+            input_path.with_name(
+                "hashtags.txt.hashformers.jsonl.job.sqlite3"
+            ).absolute()
+        ),
+        "input_path": str(input_path.absolute()),
+        "output_path": str(
+            input_path.with_name("hashtags.txt.hashformers.jsonl").absolute()
+        ),
+        "input_format": "text",
+        "status": "completed",
+        "total_hashtags": 5,
+        "unique_hashtags": 3,
+        "deduplicated_hashtags": 2,
+        "processed_unique": 3,
+        "processed_this_call": 1,
+        "remaining_unique": 0,
+        "segmenter_model": "gpt2",
+        "reranker_model": None,
+        "ranking_strategy": "segmenter",
+    }
+    assert [call.args[1] for call in pipeline.call_args_list] == [
+        ["#icecold", "#benfica"],
+        ["#mouraria"],
+    ]
+    assert [call.args[0] for call in context.report_progress.await_args_list] == [
+        0,
+        2,
+        2,
+        3,
+    ]
+    output_records = [
+        json.loads(line)
+        for line in Path(summary["output_path"])
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert [record["source_line"] for record in output_records] == [1, 2, 3, 4, 5]
+    assert [record["input"] for record in output_records] == [
+        "#icecold",
+        "#benfica",
+        "#icecold",
+        "#mouraria",
+        "#benfica",
+    ]
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        repeated = asyncio.run(continue_hashtag_file_job(summary["job_path"]))
+    assert repeated["status"] == "completed"
+    assert repeated["processed_this_call"] == 0
+    get_model.assert_not_called()
+
+
+@requires_secure_file_jobs
+def test_start_hashtag_file_job_fails_atomically_with_source_line(tmp_path):
+    """Verify malformed bulk input leaves no partial destination.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    output_path = tmp_path / "results.jsonl"
+    input_path.write_text("#icecold\n\n#mouraria\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="blank hashtag at line 2"):
+        start_hashtag_file_job(
+            str(input_path),
+            output_path=str(output_path),
+            ranking_strategy="segmenter",
+        )
+
+    assert not output_path.exists()
+    assert list(tmp_path.glob(".*.tmp")) == []
+    assert list(tmp_path.glob("*.job.sqlite3")) == []
+
+
+@requires_secure_file_jobs
+def test_start_hashtag_file_job_rejects_oversized_physical_records(tmp_path):
+    """Verify file parsing never allocates an unbounded source line.
+
+    The failed start must leave neither a checkpoint nor a partial output.
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text(
+        "a" * (mcp_server.MAX_FILE_RECORD_CHARS + 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="file records must contain at most"):
+        start_hashtag_file_job(
+            str(input_path),
+            ranking_strategy="segmenter",
+        )
+
+    assert list(tmp_path.glob("*.job.sqlite3")) == []
+
+
+@requires_secure_file_jobs
+def test_start_hashtag_file_job_rejects_unprocessable_beam_options(tmp_path):
+    """Verify a published job always has a processable one-item chunk.
+
+    Immutable search options must not leave a checkpoint permanently stuck.
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("a" * 512, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="beam-search request is too large"):
+        start_hashtag_file_job(
+            str(input_path),
+            ranking_strategy="segmenter",
+            top_k=64,
+            steps=32,
+        )
+
+    assert list(tmp_path.glob("*.job.sqlite3")) == []
+
+
+def test_start_hashtag_file_job_refuses_accidental_overwrite(tmp_path):
+    """Verify bulk output cannot replace a file without explicit permission.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    output_path = tmp_path / "results.jsonl"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    output_path.write_text("keep me", encoding="utf-8")
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="overwrite=true"):
+            start_hashtag_file_job(
+                str(input_path),
+                output_path=str(output_path),
+                ranking_strategy="segmenter",
+            )
+
+    assert output_path.read_text(encoding="utf-8") == "keep me"
+    get_model.assert_not_called()
+
+
+def test_start_hashtag_file_job_requires_startup_overwrite_policy(tmp_path):
+    """Verify a tool argument cannot independently authorize replacement.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    output_path = tmp_path / "results.jsonl"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    output_path.write_text("keep me", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="requires --allow-file-overwrite"):
+        start_hashtag_file_job(
+            str(input_path),
+            output_path=str(output_path),
+            overwrite=True,
+            ranking_strategy="segmenter",
+        )
+
+    assert output_path.read_text(encoding="utf-8") == "keep me"
+
+
+def test_start_hashtag_file_job_rejects_paths_outside_configured_roots(tmp_path):
+    """Verify file tools cannot escape the operator-authorized directories.
+
+    """
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    outside_input = tmp_path / "outside.txt"
+    outside_input.write_text("#icecold\n", encoding="utf-8")
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+
+    with pytest.raises(ValueError, match="outside configured file roots"):
+        start_hashtag_file_job(
+            str(outside_input),
+            ranking_strategy="segmenter",
+        )
+
+
+@requires_secure_file_jobs
+def test_file_job_rejects_replaced_configured_root(tmp_path):
+    """Verify a same-path directory replacement does not inherit authority.
+
+    """
+    allowed_root = tmp_path / "allowed"
+    original_root = tmp_path / "allowed-original"
+    allowed_root.mkdir()
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+    allowed_root.rename(original_root)
+    allowed_root.mkdir()
+    input_path = allowed_root / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="configured file root changed"):
+        start_hashtag_file_job(
+            str(input_path),
+            ranking_strategy="segmenter",
+        )
+
+    assert list(allowed_root.glob("*.job.sqlite3")) == []
+
+
+def test_file_job_rejects_retargeted_configured_root_symlink(tmp_path):
+    """Verify replacing a configured root with a symlink cannot widen access.
+
+    """
+    allowed_root = tmp_path / "allowed"
+    original_root = tmp_path / "allowed-original"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    input_path = outside_root / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+    allowed_root.rename(original_root)
+    allowed_root.symlink_to(outside_root, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside configured file roots"):
+        start_hashtag_file_job(
+            str(allowed_root / input_path.name),
+            ranking_strategy="segmenter",
+        )
+
+    assert list(outside_root.glob("*.job.sqlite3")) == []
+
+
+@requires_secure_file_jobs
+def test_reconfiguring_server_authorizes_replaced_file_root(tmp_path):
+    """Verify explicit reconfiguration refreshes the pinned root identity.
+
+    """
+    allowed_root = tmp_path / "allowed"
+    original_root = tmp_path / "allowed-original"
+    allowed_root.mkdir()
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+    allowed_root.rename(original_root)
+    allowed_root.mkdir()
+    input_path = allowed_root / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+
+    assert Path(job["job_path"]).is_file()
+
+
+def test_file_jobs_fail_closed_without_descriptor_support(tmp_path):
+    """Verify unsupported hosts never fall back to raceable path operations.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+
+    with patch(
+        "hashformers.mcp_server.SUPPORTS_SECURE_FILE_JOBS",
+        False,
+    ):
+        with pytest.raises(ValueError, match="secure file jobs are not supported"):
+            start_hashtag_file_job(
+                str(input_path),
+                ranking_strategy="segmenter",
+            )
+
+    assert list(tmp_path.glob("*.job.sqlite3")) == []
+
+
+@pytest.mark.skipif(
+    not hasattr(mcp_server.os, "mkfifo")
+    or not mcp_server.SUPPORTS_SECURE_FILE_JOBS,
+    reason="requires secure POSIX file operations",
+)
+def test_file_job_rejects_source_replaced_with_fifo(tmp_path):
+    """Verify a FIFO swap cannot block source validation indefinitely.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    real_open_child = mcp_server._open_child
+    swapped = False
+
+    def replace_source_before_open(*args, **kwargs):
+        """Replace the source and assert its open is nonblocking.
+
+        Args:
+            *args: Positional arguments for ``_open_child``.
+            **kwargs: Keyword arguments for ``_open_child``.
+
+        Returns:
+            A descriptor returned by the real helper.
+        """
+        nonlocal swapped
+        if not swapped and args[2] == input_path.name:
+            assert args[3] & mcp_server.os.O_NONBLOCK
+            input_path.unlink()
+            mcp_server.os.mkfifo(input_path)
+            swapped = True
+        return real_open_child(*args, **kwargs)
+
+    with patch(
+        "hashformers.mcp_server._open_child",
+        side_effect=replace_source_before_open,
+    ):
+        with pytest.raises(ValueError, match="input_path is not a readable file"):
+            start_hashtag_file_job(
+                str(input_path),
+                ranking_strategy="segmenter",
+            )
+
+    assert list(tmp_path.glob("*.job.sqlite3")) == []
+
+
+def test_continue_hashtag_file_job_enforces_hard_batch_ceiling():
+    """Verify callers cannot bypass the server's inference memory bound.
+
+    """
+    with pytest.raises(ValueError, match="max_unique_hashtags must be at most 64"):
+        asyncio.run(
+            continue_hashtag_file_job(
+                "unused.job.sqlite3",
+                max_unique_hashtags=65,
+            )
+        )
+
+
+@requires_secure_file_jobs
+def test_continue_hashtag_file_job_rejects_unmarked_sqlite_files(tmp_path):
+    """Verify an arbitrary SQLite database cannot masquerade as a checkpoint.
+
+    Validation happens before any Transformer model can be loaded.
+    """
+    checkpoint = tmp_path / "untrusted.sqlite3"
+    with sqlite3.connect(checkpoint) as connection:
+        connection.execute("CREATE TABLE metadata(key TEXT, value TEXT)")
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="not a valid Hashformers checkpoint"):
+            asyncio.run(continue_hashtag_file_job(str(checkpoint)))
+
+    get_model.assert_not_called()
+
+
+@requires_secure_file_jobs
+def test_continue_hashtag_file_job_uses_checkpoint_after_source_changes(tmp_path):
+    """Verify continuation uses indexed records instead of rereading the source.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    input_path.write_text("#mouraria\n", encoding="utf-8")
+
+    pipeline = Mock(side_effect=_mock_batch_output)
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        completed = asyncio.run(continue_hashtag_file_job(job["job_path"]))
+
+    assert completed["status"] == "completed"
+    assert pipeline.call_args.args[1] == ["#icecold"]
+
+
+@requires_secure_file_jobs
+def test_continue_hashtag_file_job_reconciles_completed_output(tmp_path):
+    """Verify retry recovers from a crash after output rename but before flagging.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch(
+            "hashformers.mcp_server._run_transformer_pipeline",
+            side_effect=_mock_batch_output,
+        ),
+    ):
+        completed = asyncio.run(continue_hashtag_file_job(job["job_path"]))
+
+    output_path = Path(completed["output_path"])
+    expected_output = output_path.read_bytes()
+    with sqlite3.connect(completed["job_path"]) as connection:
+        connection.execute(
+            "UPDATE metadata SET value = 'false' WHERE key = 'finalized'"
+        )
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        retried = asyncio.run(continue_hashtag_file_job(completed["job_path"]))
+
+    assert retried["status"] == "completed"
+    assert output_path.read_bytes() == expected_output
+    get_model.assert_not_called()
+
+
+@requires_secure_file_jobs
+def test_file_job_never_overwrites_a_destination_created_during_publish(tmp_path):
+    """Verify no-overwrite publication is atomic against a competing writer.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    output_path = tmp_path / "results.jsonl"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        output_path=str(output_path),
+        ranking_strategy="segmenter",
+    )
+    real_link = mcp_server.os.link
+
+    def create_competing_output(source, destination, *args, **kwargs):
+        """Create the destination immediately before atomic publication.
+
+        Args:
+            source: Temporary output path.
+            destination: Intended final output path.
+            *args: Positional arguments forwarded to ``os.link``.
+            **kwargs: Keyword arguments forwarded to ``os.link``.
+
+        Returns:
+            The result of the real hard-link operation.
+        """
+        descriptor = mcp_server.os.open(
+            destination,
+            mcp_server.os.O_WRONLY
+            | mcp_server.os.O_CREAT
+            | mcp_server.os.O_EXCL,
+            0o600,
+            dir_fd=kwargs["dst_dir_fd"],
+        )
+        with mcp_server.os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write("keep me")
+        return real_link(source, destination, *args, **kwargs)
+
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch(
+            "hashformers.mcp_server._run_transformer_pipeline",
+            side_effect=_mock_batch_output,
+        ),
+        patch("hashformers.mcp_server.os.link", side_effect=create_competing_output),
+    ):
+        with pytest.raises(ValueError, match="different content"):
+            asyncio.run(continue_hashtag_file_job(job["job_path"]))
+
+    assert output_path.read_text(encoding="utf-8") == "keep me"
+
+
+@pytest.mark.skipif(
+    not hasattr(mcp_server.os, "mkfifo")
+    or not mcp_server.SUPPORTS_SECURE_FILE_JOBS,
+    reason="requires secure POSIX file operations",
+)
+def test_file_job_rejects_fifo_created_during_publication(tmp_path):
+    """Verify an empty competing FIFO is never accepted as valid output.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    output_path = tmp_path / "results.jsonl"
+    input_path.write_text("", encoding="utf-8")
+    real_link = mcp_server.os.link
+    real_open_child = mcp_server._open_child
+    competing_output_created = False
+
+    def create_competing_fifo(source, destination, *args, **kwargs):
+        """Create a FIFO immediately before final output publication.
+
+        Args:
+            source: Temporary output basename.
+            destination: Intended final output basename.
+            *args: Positional arguments forwarded to ``os.link``.
+            **kwargs: Descriptor arguments forwarded to ``os.link``.
+
+        Returns:
+            The result of the real hard-link operation.
+        """
+        nonlocal competing_output_created
+        if destination == output_path.name:
+            mcp_server.os.mkfifo(
+                destination,
+                dir_fd=kwargs["dst_dir_fd"],
+            )
+            competing_output_created = True
+        return real_link(source, destination, *args, **kwargs)
+
+    def assert_nonblocking_output_open(*args, **kwargs):
+        """Require nonblocking flags when the competing output is inspected.
+
+        Args:
+            *args: Positional arguments for ``_open_child``.
+            **kwargs: Keyword arguments for ``_open_child``.
+
+        Returns:
+            A descriptor returned by the real helper.
+        """
+        if competing_output_created and args[2] == output_path.name:
+            assert args[3] & mcp_server.os.O_NONBLOCK
+        return real_open_child(*args, **kwargs)
+
+    with (
+        patch(
+            "hashformers.mcp_server.os.link",
+            side_effect=create_competing_fifo,
+        ),
+        patch(
+            "hashformers.mcp_server._open_child",
+            side_effect=assert_nonblocking_output_open,
+        ),
+    ):
+        with pytest.raises(ValueError, match="output_path must be a regular file"):
+            start_hashtag_file_job(
+                str(input_path),
+                output_path=str(output_path),
+                ranking_strategy="segmenter",
+            )
+
+    assert stat.S_ISFIFO(output_path.stat().st_mode)
+
+
+@requires_secure_file_jobs
+def test_file_job_publication_stays_bound_to_authorized_directory(tmp_path):
+    """Verify a symlink swap cannot redirect final output outside a file root.
+
+    Publication uses the directory descriptor opened before the swap.
+    """
+    allowed_root = tmp_path / "allowed"
+    work_directory = allowed_root / "work"
+    outside_directory = tmp_path / "outside"
+    work_directory.mkdir(parents=True)
+    outside_directory.mkdir()
+    input_path = work_directory / "hashtags.txt"
+    output_path = work_directory / "results.jsonl"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    configure_server(ServerConfig(file_roots=(str(allowed_root),)))
+    job = start_hashtag_file_job(
+        str(input_path),
+        output_path=str(output_path),
+        ranking_strategy="segmenter",
+    )
+    original_directory = allowed_root / "work-original"
+    real_link = mcp_server.os.link
+    swapped = False
+
+    def swap_parent_then_link(source, destination, *args, **kwargs):
+        """Swap the visible path, then publish through the anchored descriptor.
+
+        Args:
+            source: Temporary output basename.
+            destination: Final output basename.
+            *args: Positional arguments forwarded to ``os.link``.
+            **kwargs: Descriptor arguments forwarded to ``os.link``.
+
+        Returns:
+            The result of the real hard-link operation.
+        """
+        nonlocal swapped
+        if not swapped:
+            work_directory.rename(original_directory)
+            work_directory.symlink_to(outside_directory, target_is_directory=True)
+            swapped = True
+        return real_link(source, destination, *args, **kwargs)
+
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch(
+            "hashformers.mcp_server._run_transformer_pipeline",
+            side_effect=_mock_batch_output,
+        ),
+        patch(
+            "hashformers.mcp_server.os.link",
+            side_effect=swap_parent_then_link,
+        ),
+    ):
+        with pytest.raises(ValueError, match="directory changed"):
+            asyncio.run(continue_hashtag_file_job(job["job_path"]))
+
+    assert (original_directory / "results.jsonl").is_file()
+    assert list(outside_directory.iterdir()) == []
+
+
+@requires_secure_file_jobs
+def test_concurrent_continuations_do_not_duplicate_inference(tmp_path):
+    """Verify one checkpoint permits only one active inference claimant.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    entered = Event()
+    release = Event()
+
+    def blocking_pipeline(segmenter, inputs, **kwargs):
+        """Hold one model call while a competing continuation starts.
+
+        Args:
+            segmenter: Configured model wrapper.
+            inputs: Current hashtag batch.
+            **kwargs: Pipeline options.
+
+        Returns:
+            A deterministic ranked batch after the test releases it.
+        """
+        entered.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("test did not release model inference")
+        return _mock_batch_output(segmenter, inputs, **kwargs)
+
+    async def exercise_concurrency():
+        first_task = asyncio.create_task(
+            continue_hashtag_file_job(job["job_path"])
+        )
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        try:
+            with pytest.raises(ValueError, match="already being processed"):
+                await continue_hashtag_file_job(job["job_path"])
+        finally:
+            release.set()
+        return await first_task
+
+    pipeline = Mock(side_effect=blocking_pipeline)
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        completed = asyncio.run(exercise_concurrency())
+
+    assert completed["status"] == "completed"
+    pipeline.assert_called_once()
+
+
+@requires_secure_file_jobs
+def test_cancelled_continuation_keeps_its_checkpoint_claim(tmp_path):
+    """Verify cancellation cannot launch duplicate inference for one batch.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    entered = Event()
+    release = Event()
+
+    def blocking_pipeline(segmenter, inputs, **kwargs):
+        """Hold inference after cancellation until the test permits completion.
+
+        Args:
+            segmenter: Configured model wrapper.
+            inputs: Current hashtag batch.
+            **kwargs: Pipeline options.
+
+        Returns:
+            A deterministic ranked batch.
+        """
+        entered.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("test did not release model inference")
+        return _mock_batch_output(segmenter, inputs, **kwargs)
+
+    async def exercise_cancellation():
+        first_task = asyncio.create_task(
+            continue_hashtag_file_job(job["job_path"])
+        )
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        first_task.cancel()
+        await asyncio.sleep(0.05)
+        try:
+            with pytest.raises(ValueError, match="already being processed"):
+                await asyncio.wait_for(
+                    continue_hashtag_file_job(job["job_path"]),
+                    timeout=1,
+                )
+        finally:
+            release.set()
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            with sqlite3.connect(job["job_path"]) as connection:
+                processed = connection.execute(
+                    "SELECT COUNT(*) FROM unique_hashtags "
+                    "WHERE result_json IS NOT NULL"
+                ).fetchone()[0]
+                finalized = connection.execute(
+                    "SELECT value FROM metadata WHERE key = 'finalized'"
+                ).fetchone()[0]
+            if processed == 1 and finalized == "true":
+                break
+        else:
+            raise AssertionError("cancelled worker did not checkpoint its result")
+        try:
+            return await first_task
+        except asyncio.CancelledError:
+            return None
+
+    pipeline = Mock(side_effect=blocking_pipeline)
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        asyncio.run(exercise_cancellation())
+
+    pipeline.assert_called_once()
+    with sqlite3.connect(job["job_path"]) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM unique_hashtags WHERE result_json IS NOT NULL"
+        ).fetchone()[0] == 1
+
+
+@requires_secure_file_jobs
+def test_large_file_finalization_runs_outside_the_event_loop(tmp_path):
+    """Verify rendering a completed output does not block other MCP requests.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#icecold\n", encoding="utf-8")
+    job = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="segmenter",
+    )
+    event_loop_thread = get_ident()
+    finalizer_threads = []
+    real_finalizer = mcp_server._finalize_file_job
+
+    def record_finalizer_thread(*args, **kwargs):
+        """Record the worker thread before delegating to the real finalizer.
+
+        Args:
+            *args: Positional finalizer arguments.
+            **kwargs: Keyword finalizer arguments.
+
+        Returns:
+            The real finalizer result.
+        """
+        finalizer_threads.append(get_ident())
+        return real_finalizer(*args, **kwargs)
+
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch(
+            "hashformers.mcp_server._run_transformer_pipeline",
+            side_effect=_mock_batch_output,
+        ),
+        patch(
+            "hashformers.mcp_server._finalize_file_job",
+            side_effect=record_finalizer_thread,
+        ),
+    ):
+        asyncio.run(continue_hashtag_file_job(job["job_path"]))
+
+    assert finalizer_threads
+    assert finalizer_threads[0] != event_loop_thread
+
+
+@requires_secure_file_jobs
+def test_empty_hashtag_file_job_completes_without_loading_model(tmp_path):
+    """Verify empty input creates an empty final output immediately.
+
+    """
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("", encoding="utf-8")
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        job = start_hashtag_file_job(
+            str(input_path),
+            ranking_strategy="segmenter",
+        )
+
+    assert job["status"] == "completed"
+    assert job["total_hashtags"] == 0
+    assert Path(job["output_path"]).read_text(encoding="utf-8") == ""
+    get_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("filename", "contents", "input_format", "input_field", "expected"),
+    [
+        (
+            "hashtags.csv",
+            "tag,label\n#icecold,a\n#mouraria,b\n",
+            "csv",
+            "tag",
+            [(2, "#icecold"), (3, "#mouraria")],
+        ),
+        (
+            "hashtags.jsonl",
+            '"#icecold"\n{"tag": "#mouraria"}\n',
+            "jsonl",
+            "tag",
+            [(1, "#icecold"), (2, "#mouraria")],
+        ),
+    ],
+)
+def test_file_reader_preserves_source_lines_across_formats(
+    tmp_path,
+    filename,
+    contents,
+    input_format,
+    input_field,
+    expected,
+):
+    """Verify CSV and JSON Lines inputs retain traceable source locations.
+
+    """
+    input_path = tmp_path / filename
+    input_path.write_text(contents, encoding="utf-8")
+
+    records = list(
+        mcp_server._iter_file_hashtags(input_path, input_format, input_field)
+    )
+
+    assert records == expected
+
+
+def test_segment_with_regex_exposes_rules_and_preprocessing():
+    """Verify regex rules run sequentially through the MCP surface.
+
+    """
+    result = segment_with_regex(
+        ["#fooBAR123", "#zipZIP456"],
+        regex_rules=[r"([A-Z]+)", r"([0-9]+)"],
+    )
+
+    assert result == {
+        "results": [
+            {
+                "input": "#fooBAR123",
+                "normalized_input": "fooBAR123",
+                "segmentation": "foo BAR 123",
+            },
+            {
+                "input": "#zipZIP456",
+                "normalized_input": "zipZIP456",
+                "segmentation": "zip ZIP 456",
+            },
         ]
     }
 
 
-@pytest.mark.parametrize("top_k", [0, -1, True, 1.5])
-def test_segment_hashtags_rejects_invalid_top_k_without_loading_model(top_k):
-    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
-        with pytest.raises(ValueError, match="top_k must be a positive integer"):
-            segment_hashtags(["#icecold"], top_k=top_k)
+def test_segment_with_regex_rejects_invalid_rules():
+    """Verify malformed regex configuration fails clearly.
 
-    segmenter_class.assert_not_called()
-
-
-@pytest.mark.parametrize("hashtag", ["", "#", "###", "#   "])
-def test_segment_hashtags_rejects_blank_hashtags_without_loading_model(hashtag):
-    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
-        with pytest.raises(ValueError, match="hashtags must contain text"):
-            segment_hashtags([hashtag])
-
-    segmenter_class.assert_not_called()
+    """
+    with pytest.raises(ValueError, match="invalid regex rule"):
+        segment_with_regex(["foo"], regex_rules=["("])
 
 
-def test_segment_hashtags_handles_empty_input_without_loading_model():
-    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
-        assert segment_hashtags([]) == {"results": []}
+def test_segment_with_regex_times_out_pathological_rules():
+    """Verify caller-controlled patterns cannot monopolize the MCP process.
 
-    segmenter_class.assert_not_called()
+    """
+    with patch("hashformers.mcp_server.REGEX_TIMEOUT_SECONDS", 0):
+        with pytest.raises(ValueError, match="execution timeout"):
+            segment_with_regex(
+                ["a" * 5_000 + "!"],
+                regex_rules=[r"(a+)+$"],
+            )
 
 
-def test_main_runs_server_over_stdio():
+def test_segment_with_regex_bounds_sequential_output_growth():
+    """Verify one regex result cannot become the next rule's huge input.
+
+    The limit is checked after every sequential substitution.
+    """
+    with patch("hashformers.mcp_server.MAX_REGEX_OUTPUT_LENGTH", 4):
+        with pytest.raises(ValueError, match="oversized intermediate result"):
+            segment_with_regex(["abc"], regex_rules=[r"(.)"])
+
+
+def test_segment_tweets_uses_regex_by_default_and_reports_occurrences():
+    """Verify the MCP mirrors ``TweetSegmenter`` default behavior.
+
+    """
+    result = segment_tweets(
+        ["First #fooBAR123 and #fooBAR123", "No tags"],
+        regex_rules=[r"([A-Z]+)", r"([0-9]+)"],
+    )
+
+    assert result["results"][0]["segmented_text"] == (
+        "First foo BAR 123 and foo BAR 123"
+    )
+    assert [
+        item["selected_segmentation"] for item in result["results"][0]["hashtags"]
+    ] == ["foo BAR 123", "foo BAR 123"]
+    assert result["results"][1] == {
+        "input": "No tags",
+        "segmented_text": "No tags",
+        "hashtags": [],
+    }
+
+
+def test_segment_tweets_without_hashtags_does_not_load_transformer():
+    """Verify Transformer mode is lazy when tweets contain no hashtags.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        result = segment_tweets(
+            ["No tags here"],
+            segmenter_kind="transformer",
+        )
+
+    assert result["results"][0]["segmented_text"] == "No tags here"
+    get_model.assert_not_called()
+
+
+def test_segment_tweets_rejects_unsupported_hashtag_markers():
+    """Verify custom markers fail rather than silently leaving text unchanged.
+
+    """
+    with pytest.raises(ValueError, match="supports only hashtag_character='#'"):
+        segment_tweets(["Try !icecold"], hashtag_character="!")
+
+
+def test_segment_tweets_bounds_replacement_strings_and_occurrences():
+    """Verify tweet options cannot amplify a small request without limit.
+
+    Both caller-controlled replacement text and repeated hashtag details are capped.
+    """
+    with pytest.raises(ValueError, match="hashtag_token must contain at most"):
+        segment_tweets(
+            ["Try #icecold"],
+            hashtag_token="x" * (mcp_server.MAX_TWEET_REPLACEMENT_CHARS + 1),
+        )
+
+    repeated_hashtags = " ".join(
+        f"#tag{index}"
+        for index in range(mcp_server.MAX_TWEET_HASHTAG_OCCURRENCES + 1)
+    )
+    with pytest.raises(ValueError, match="hashtag occurrences"):
+        segment_tweets([repeated_hashtags])
+
+
+def test_rank_candidates_selects_precomputed_scores_without_loading_model():
+    """Verify direct selection never reruns beam search or loads a model.
+
+    """
+    candidate_sets = [
+        {
+            "input": "#icecold",
+            "candidates": [
+                {"segmentation": "ice cold", "score": 1.0},
+                {"segmentation": "i ce cold", "score": 2.0},
+            ],
+        }
+    ]
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        result = rank_candidates(
+            candidate_sets,
+            ranking_strategy="segmenter",
+            include_component_rankings=True,
+        )
+
+    assert result["results"][0]["selected_segmentation"] == "ice cold"
+    assert result["results"][0]["component_rankings"]["reranker"] is None
+    get_model.assert_not_called()
+
+
+def test_rank_candidates_passes_precomputed_run_to_reranker_pipeline():
+    """Verify reranking consumes supplied candidates instead of beam search.
+
+    """
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+    segmenter = mcp_server.BaseWordSegmenter()
+    pipeline = Mock(
+        return_value=WordSegmenterOutput(
+            output=["i ce cold"],
+            segmenter_rank=_rank([("ice cold", 1.0), ("i ce cold", 2.0)]),
+            reranker_rank=_rank([("i ce cold", 0.5), ("ice cold", 1.5)]),
+        )
+    )
+
+    with (
+        patch("hashformers.mcp_server.get_segmenter", return_value=segmenter),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = rank_candidates(
+            [
+                {
+                    "input": "icecold",
+                    "candidates": [
+                        {"segmentation": "ice cold", "score": 1.0},
+                        {"segmentation": "i ce cold", "score": 2.0},
+                    ],
+                }
+            ],
+            ranking_strategy="reranker",
+        )
+
+    assert result["results"][0]["selected_segmentation"] == "i ce cold"
+    assert pipeline.call_args.args == (segmenter, ["icecold"])
+    kwargs = pipeline.call_args.kwargs
+    assert kwargs["segmenter_run"].dictionary == {
+        "ice cold": 1.0,
+        "i ce cold": 2.0,
+    }
+    assert kwargs["strategy"] == "reranker"
+
+
+def test_rank_candidates_batches_candidate_sets_for_reranking():
+    """Verify multiple candidate sets share one GPU-backed reranker call.
+
+    """
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+
+    def batched_output(_segmenter, inputs, **kwargs):
+        """Return the supplied global precomputed ranking unchanged.
+
+        Args:
+            _segmenter: Unused configured model wrapper.
+            inputs: Normalized candidate-set inputs.
+            **kwargs: Pipeline options including the precomputed run.
+
+        Returns:
+            A ranked output aligned with every input.
+        """
+        rank = kwargs["segmenter_run"].to_dataframe()
+        return WordSegmenterOutput(
+            output=["ice cold", "ben fica"],
+            segmenter_rank=rank,
+            reranker_rank=rank,
+        )
+
+    pipeline = Mock(side_effect=batched_output)
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = rank_candidates(
+            [
+                {
+                    "input": "icecold",
+                    "candidates": [
+                        {"segmentation": "ice cold", "score": 1.0},
+                        {"segmentation": "i ce cold", "score": 2.0},
+                    ],
+                },
+                {
+                    "input": "benfica",
+                    "candidates": [
+                        {"segmentation": "ben fica", "score": 1.0},
+                        {"segmentation": "benfi ca", "score": 2.0},
+                    ],
+                },
+            ],
+            ranking_strategy="reranker",
+        )
+
+    assert [item["selected_segmentation"] for item in result["results"]] == [
+        "ice cold",
+        "ben fica",
+    ]
+    pipeline.assert_called_once()
+    assert pipeline.call_args.args[1] == ["icecold", "benfica"]
+
+
+def test_rank_candidates_isolates_colliding_candidate_sets():
+    """Verify equal character strings do not share each other's hypotheses.
+
+    """
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+
+    def isolated_output(_segmenter, inputs, **kwargs):
+        """Return only the candidates supplied in the current isolated batch.
+
+        Args:
+            _segmenter: Unused configured model wrapper.
+            inputs: Normalized candidate-set inputs.
+            **kwargs: Pipeline options including the precomputed run.
+
+        Returns:
+            A ranked output aligned with the isolated input.
+        """
+        rank = kwargs["segmenter_run"].to_dataframe()
+        selected = rank.sort_values("score").iloc[0]["segmentation"]
+        return WordSegmenterOutput(
+            output=[selected],
+            segmenter_rank=rank,
+            reranker_rank=rank,
+        )
+
+    pipeline = Mock(side_effect=isolated_output)
+    with (
+        patch(
+            "hashformers.mcp_server.get_segmenter",
+            return_value=mcp_server.BaseWordSegmenter(),
+        ),
+        patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
+    ):
+        result = rank_candidates(
+            [
+                {
+                    "input": "icecold",
+                    "candidates": [
+                        {"segmentation": "ice cold", "score": 1.0},
+                    ],
+                },
+                {
+                    "input": "icecold",
+                    "candidates": [
+                        {"segmentation": "i ce cold", "score": 1.0},
+                    ],
+                },
+            ],
+            ranking_strategy="reranker",
+        )
+
+    assert [item["selected_segmentation"] for item in result["results"]] == [
+        "ice cold",
+        "i ce cold",
+    ]
+    assert pipeline.call_count == 2
+
+
+def test_rank_candidates_rejects_unbounded_whitespace_hypotheses():
+    """Verify candidate boundaries cannot bypass request-size ceilings.
+
+    """
+    with pytest.raises(ValueError, match="single spaces as boundaries"):
+        rank_candidates(
+            [
+                {
+                    "input": "icecold",
+                    "candidates": [
+                        {"segmentation": "ice" + (" " * 5_000) + "cold", "score": 1},
+                    ],
+                }
+            ],
+            ranking_strategy="segmenter",
+        )
+
+
+@pytest.mark.parametrize(
+    "candidate_sets",
+    [
+        [{"input": "icecold", "candidates": []}],
+        [
+            {
+                "input": "icecold",
+                "candidates": [
+                    {"segmentation": "ice cold", "score": 1.0},
+                    {"segmentation": "ice cold", "score": 2.0},
+                ],
+            }
+        ],
+        [
+            {
+                "input": "icecold",
+                "candidates": [
+                    {"segmentation": "wrong text", "score": 1.0},
+                ],
+            }
+        ],
+    ],
+)
+def test_rank_candidates_rejects_invalid_candidate_sets(candidate_sets):
+    """Verify malformed precomputed runs are rejected before model loading.
+
+    """
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError):
+            rank_candidates(candidate_sets, ranking_strategy="segmenter")
+
+    get_model.assert_not_called()
+
+
+def test_mcp_server_exposes_complete_structured_surface():
+    """Verify agents discover every supported MCP segmentation workflow.
+
+    """
+
+    async def list_tools():
+        async with Client(mcp) as client:
+            return await client.list_tools()
+
+    tools = asyncio.run(list_tools()).tools
+    tools_by_name = {tool.name: tool for tool in tools}
+
+    assert set(tools_by_name) == {
+        "segment_hashtags",
+        "start_hashtag_file_job",
+        "continue_hashtag_file_job",
+        "segment_with_regex",
+        "segment_tweets",
+        "rank_candidates",
+    }
+    assert tools_by_name["segment_hashtags"].annotations.read_only_hint is True
+    assert tools_by_name["segment_with_regex"].annotations.open_world_hint is False
+    assert tools_by_name["start_hashtag_file_job"].annotations.destructive_hint is True
+    assert (
+        tools_by_name["continue_hashtag_file_job"].annotations.open_world_hint
+        is True
+    )
+    hashtag_schema = tools_by_name["segment_hashtags"].input_schema["properties"]
+    assert hashtag_schema["top_k"]["default"] == 5
+    assert hashtag_schema["steps"]["default"] == 5
+    assert hashtag_schema["max_candidates"]["default"] == 5
+    assert hashtag_schema["ranking_strategy"]["default"] == "auto"
+    file_schema = tools_by_name["continue_hashtag_file_job"].input_schema["properties"]
+    assert "context" not in file_schema
+
+
+def test_mcp_transport_validates_nested_candidate_contract():
+    """Verify precomputed candidates cross the real MCP serialization layer.
+
+    """
+
+    async def call_tool():
+        async with Client(mcp) as client:
+            return await client.call_tool(
+                "rank_candidates",
+                {
+                    "candidate_sets": [
+                        {
+                            "input": "icecold",
+                            "candidates": [
+                                {"segmentation": "ice cold", "score": 1.0},
+                                {"segmentation": "i ce cold", "score": 2.0},
+                            ],
+                        }
+                    ],
+                    "ranking_strategy": "segmenter",
+                },
+            )
+
+    result = asyncio.run(call_tool())
+
+    assert result.is_error is False
+    assert result.structured_content["results"][0]["selected_segmentation"] == (
+        "ice cold"
+    )
+
+
+def test_main_configures_server_and_runs_stdio():
+    """Verify the console entry point applies CLI settings before serving.
+
+    """
     with patch.object(mcp, "run") as run:
-        main()
+        main(["--model", "custom/gpt", "--batch-size", "9"])
 
+    assert mcp_server._server_config.segmenter_model == "custom/gpt"
+    assert mcp_server._server_config.segmenter_batch_size == 9
     run.assert_called_once_with(transport="stdio")

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -32,6 +32,19 @@ def test_supported_python_and_transformers_versions(monkeypatch):
     assert "Programming Language :: Python :: 3.9" not in metadata["classifiers"]
 
 
+def test_mcp_server_is_an_optional_extra(monkeypatch):
+    metadata = read_setup_kwargs(monkeypatch)
+
+    assert metadata["extras_require"]["mcp"] == ["mcp>=2,<3"]
+    assert all(
+        not dependency.startswith("mcp")
+        for dependency in metadata["install_requires"]
+    )
+    assert metadata["entry_points"]["console_scripts"] == [
+        "hashformers-mcp=hashformers.mcp_server:main",
+    ]
+
+
 def test_dependency_files_and_readme_match_package_metadata():
     requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -39,3 +52,13 @@ def test_dependency_files_and_readme_match_package_metadata():
     assert "transformers>=4.46.1,<6" in requirements
     assert "Python 3.10 or newer" in readme
     assert "Transformers 4.46.1" in readme
+
+
+def test_readme_documents_mcp_and_agent_skill_setup():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert 'pip install "hashformers[mcp]"' in readme
+    assert "codex mcp add hashformers -- hashformers-mcp" in readme
+    assert "claude mcp add --transport stdio --scope user" in readme
+    assert ".agents/skills/segment-hashtags" in readme
+    assert "~/.claude/skills" in readme

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -35,7 +35,11 @@ def test_supported_python_and_transformers_versions(monkeypatch):
 def test_mcp_server_is_an_optional_extra(monkeypatch):
     metadata = read_setup_kwargs(monkeypatch)
 
-    assert metadata["extras_require"]["mcp"] == ["mcp>=2,<3"]
+    assert metadata["extras_require"]["mcp"] == [
+        "anyio>=4.9",
+        "mcp>=2,<3",
+        "regex",
+    ]
     assert all(
         not dependency.startswith("mcp")
         for dependency in metadata["install_requires"]


### PR DESCRIPTION
## Summary

- expose the complete public Hashformers workflow through six structured MCP tools: Transformer segmentation, resumable file jobs, regex segmentation, tweet segmentation, and ranking/reranking of precomputed candidates
- configure segmenter and optional reranker models, scorer types, devices, and batch sizes at server startup; load the model pipeline lazily and reuse one process-wide instance
- add bounded, resumable SQLite file jobs that deduplicate normalized hashtags while preserving every source row, duplicate, and original order in the final JSON Lines output
- expand the `segment-hashtags` Agent Skill to select the appropriate workflow without copying large local files into agent context

## Resource and filesystem safety

- cap interactive batches, beam width/depth, aggregate beam expansions, candidate payloads, regex work, tweet expansion, and file-job inference chunks
- checkpoint model results before publication; make continuations concurrency-, cancellation-, and crash-safe
- require dual authorization for overwrite and publish outputs atomically
- pin authorized roots by descriptor and inode, reject symlink/root swaps and special files, and keep SQLite bound to verified descriptors
- fail file jobs closed on hosts without Linux `/proc/self/fd` support; non-file MCP tools remain portable

## Validation

- `99 passed` in the full CPU-safe suite
- `71 passed` in the focused MCP suite
- simulated unsupported host: `54 passed, 17 skipped`
- Python compilation, diff/style checks, and Agent Skill validation pass
- wheel build verifies the `mcp` extra and `hashformers-mcp` console entry point
- the GPU-only segmenter module was not run because CUDA is unavailable in this environment

Closes #66
Closes #67