### PR TITLE
Add reciprocal rank ensemble fusion

### DIFF
--- a/src/hashformers/beamsearch/data_structures.py
+++ b/src/hashformers/beamsearch/data_structures.py
@@ -96,8 +96,8 @@ class ProbabilityDictionary(object):
             score_field=score_field
         )
         df = df\
-        .sort_values(by=score_field, ascending=True)\
-        .groupby(characters_field)\
+        .sort_values(by=score_field, ascending=True, kind='stable')\
+        .groupby(characters_field, sort=False)\
         .head(k)
         if fill == False and return_dataframe == True:
             return df
@@ -146,9 +146,10 @@ class ProbabilityDictionary(object):
         df = pd.DataFrame(df)
         df = df.sort_values(
             by=[
-                characters_field, 
+                characters_field,
                 score_field
-            ]
+            ],
+            kind='stable'
         )
         return df
     

--- a/src/hashformers/ensemble/__init__.py
+++ b/src/hashformers/ensemble/__init__.py
@@ -1,0 +1,11 @@
+from hashformers.ensemble.rrf_fusion import (
+    ReciprocalRankFusionEnsembler,
+    reciprocal_rank_fusion,
+)
+from hashformers.ensemble.top2_fusion import Top2_Ensembler
+
+__all__ = [
+    "ReciprocalRankFusionEnsembler",
+    "Top2_Ensembler",
+    "reciprocal_rank_fusion",
+]

--- a/src/hashformers/ensemble/rrf_fusion.py
+++ b/src/hashformers/ensemble/rrf_fusion.py
@@ -1,0 +1,112 @@
+"""Full-list reciprocal-rank fusion for segmentation candidates."""
+
+import math
+from collections.abc import Mapping, Sequence
+
+from hashformers.beamsearch.data_structures import (
+    ProbabilityDictionary,
+    enforce_prob_dict,
+)
+
+
+def _validate_options(rrf_k, weights):
+    if isinstance(rrf_k, bool) or not isinstance(rrf_k, (int, float)):
+        raise ValueError("rrf_k must be a finite nonnegative number")
+    rrf_k = float(rrf_k)
+    if not math.isfinite(rrf_k) or rrf_k < 0:
+        raise ValueError("rrf_k must be a finite nonnegative number")
+    if len(weights) == 0:
+        raise ValueError("fusion weights must not be empty")
+    validated = []
+    for weight in weights:
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
+            raise ValueError("fusion weights must be finite nonnegative numbers")
+        weight = float(weight)
+        if not math.isfinite(weight) or weight < 0:
+            raise ValueError("fusion weights must be finite nonnegative numbers")
+        validated.append(weight)
+    if not any(validated):
+        raise ValueError("fusion weights must not all be zero")
+    return rrf_k, validated
+
+
+def _competition_ranks(probability_dictionary):
+    """Return one-based competition ranks grouped by normalized input."""
+    frame = (
+        enforce_prob_dict(probability_dictionary)
+        .to_dataframe()
+        .reset_index(drop=True)
+    )
+    result = {}
+    for characters, group in frame.groupby("characters", sort=False):
+        group = group.sort_values("score", kind="stable")
+        ranks = group["score"].rank(method="min", ascending=True).astype(int)
+        result[characters] = list(zip(group["segmentation"], ranks))
+    return result
+
+
+def reciprocal_rank_fusion(rankings: Sequence, weights=None, rrf_k=60):
+    """Fuse complete lower-is-better rankings and return lower-is-better scores."""
+    if (
+        not isinstance(rankings, Sequence)
+        or isinstance(rankings, (str, bytes))
+        or not rankings
+    ):
+        raise ValueError("rankings must be a non-empty sequence")
+    if weights is None:
+        weights = [1.0] * len(rankings)
+    if not isinstance(weights, Sequence) or isinstance(weights, (str, bytes)):
+        raise ValueError("fusion weights must be a sequence")
+    if len(weights) != len(rankings):
+        raise ValueError("fusion weights must match the number of rankings")
+    rrf_k, weights = _validate_options(rrf_k, weights)
+    component_ranks = [_competition_ranks(ranking) for ranking in rankings]
+    fused = {}
+    character_order = []
+    for component in component_ranks:
+        for characters in component:
+            if characters not in character_order:
+                character_order.append(characters)
+    for characters in character_order:
+        candidate_order = []
+        rank_maps = []
+        for component in component_ranks:
+            entries = component.get(characters, [])
+            rank_map = dict(entries)
+            rank_maps.append(rank_map)
+            for candidate, _ in entries:
+                if candidate not in candidate_order:
+                    candidate_order.append(candidate)
+        scored = []
+        for stable_position, candidate in enumerate(candidate_order):
+            score = sum(
+                weight / (rrf_k + rank_map[candidate])
+                for weight, rank_map in zip(weights, rank_maps)
+                if candidate in rank_map
+            )
+            fallbacks = tuple(
+                rank_map.get(candidate, math.inf) for rank_map in rank_maps
+            )
+            scored.append((candidate, -score, fallbacks, stable_position))
+        scored.sort(key=lambda item: (item[1], *item[2], item[3]))
+        for candidate, score, _, _ in scored:
+            fused[candidate] = score
+    return ProbabilityDictionary(fused)
+
+
+class ReciprocalRankFusionEnsembler:
+    """Adapt segmenter and reranker outputs to full-list weighted RRF."""
+
+    def run(self, segmenter_run, reranker_run, rrf_k=60, fusion_weights=None):
+        if fusion_weights is None:
+            fusion_weights = {"segmenter": 1.0, "reranker": 1.0}
+        if not isinstance(fusion_weights, Mapping):
+            raise ValueError("fusion_weights must be an object")
+        unknown = set(fusion_weights) - {"segmenter", "reranker"}
+        if unknown or set(fusion_weights) != {"segmenter", "reranker"}:
+            raise ValueError("fusion_weights must contain segmenter and reranker")
+        return reciprocal_rank_fusion(
+            [segmenter_run, reranker_run],
+            weights=[fusion_weights["segmenter"], fusion_weights["reranker"]],
+            rrf_k=rrf_k,
+        )

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -42,6 +42,7 @@ from hashformers.segmenter.data_structures import WordSegmenterOutput
 
 RankingStrategy = Literal["auto", "segmenter", "reranker", "ensemble"]
 ResolvedRankingStrategy = Literal["segmenter", "reranker", "ensemble"]
+FusionMethod = Literal["top2", "rrf"]
 FileInputFormat = Literal["auto", "text", "csv", "jsonl"]
 HubModelRole = Literal["segmenter", "reranker"]
 SupportedScorerType = Literal["gpt2", "bert", "incremental", "masked", "seq2seq"]
@@ -176,6 +177,7 @@ class SegmentationResult(TypedDict):
     normalized_input: str
     selected_segmentation: str
     ranking_strategy: ResolvedRankingStrategy
+    fusion_method: FusionMethod
     candidates: list[Candidate]
     component_rankings: ComponentRankings | None
 
@@ -313,6 +315,7 @@ class FileJobStatus(TypedDict):
     reranker_model: str | None
     reranker_revision: str | None
     ranking_strategy: ResolvedRankingStrategy
+    fusion_method: FusionMethod
 
 
 @dataclass(frozen=True)
@@ -1943,6 +1946,9 @@ def _validate_runtime_options(
     beta: float,
     max_candidates: int,
     hashtag_character: str,
+    fusion_method: FusionMethod = "top2",
+    rrf_k: float = 60,
+    fusion_weights: Mapping[str, float] | None = None,
 ) -> None:
     """Validate shared Transformer inference options.
 
@@ -1963,6 +1969,40 @@ def _validate_runtime_options(
     _validate_finite(beta, "beta")
     _validate_max_candidates(max_candidates)
     _validate_hashtag_character(hashtag_character)
+    _validate_fusion_options(fusion_method, rrf_k, fusion_weights)
+
+
+def _validate_fusion_options(
+    fusion_method: FusionMethod,
+    rrf_k: float,
+    fusion_weights: Mapping[str, float] | None,
+) -> None:
+    if fusion_method not in {"top2", "rrf"}:
+        raise ValueError("fusion_method must be top2 or rrf")
+    if isinstance(rrf_k, bool) or not isinstance(rrf_k, (int, float)):
+        raise ValueError("rrf_k must be a finite nonnegative number")
+    if not math.isfinite(float(rrf_k)) or rrf_k < 0:
+        raise ValueError("rrf_k must be a finite nonnegative number")
+    weights = (
+        {"segmenter": 1.0, "reranker": 1.0}
+        if fusion_weights is None
+        else fusion_weights
+    )
+    if not isinstance(weights, Mapping) or set(weights) != {
+        "segmenter",
+        "reranker",
+    }:
+        raise ValueError("fusion_weights must contain segmenter and reranker")
+    for weight in weights.values():
+        if (
+            isinstance(weight, bool)
+            or not isinstance(weight, (int, float))
+            or not math.isfinite(float(weight))
+            or weight < 0
+        ):
+            raise ValueError("fusion weights must be finite nonnegative numbers")
+    if not any(float(weight) for weight in weights.values()):
+        raise ValueError("fusion weights must not all be zero")
 
 
 def _resolve_ranking_strategy(strategy: RankingStrategy) -> ResolvedRankingStrategy:
@@ -2012,6 +2052,9 @@ def _run_transformer_pipeline(
     steps: int,
     alpha: float,
     beta: float,
+    fusion_method: FusionMethod,
+    rrf_k: float,
+    fusion_weights: Mapping[str, float] | None,
     strategy: ResolvedRankingStrategy,
     preprocessing_kwargs: dict,
     segmenter_run=None,
@@ -2039,7 +2082,12 @@ def _run_transformer_pipeline(
         segmenter_run=segmenter_run,
         preprocessing_kwargs=preprocessing_kwargs,
         segmenter_kwargs={"topk": top_k, "steps": steps},
-        ensembler_kwargs={"alpha": alpha, "beta": beta},
+        ensembler_kwargs=(
+            {"rrf_k": rrf_k, "fusion_weights": fusion_weights}
+            if fusion_method == "rrf"
+            else {"alpha": alpha, "beta": beta}
+        ),
+        fusion_method=fusion_method,
         use_reranker=use_reranker,
         use_ensembler=use_ensembler,
         return_ranks=True,
@@ -2129,6 +2177,7 @@ def _serialize_word_output(
     strategy: ResolvedRankingStrategy,
     max_candidates: int,
     include_component_rankings: bool,
+    fusion_method: FusionMethod = "top2",
 ) -> list[SegmentationResult]:
     """Serialize a ``WordSegmenterOutput`` for MCP.
 
@@ -2208,6 +2257,7 @@ def _serialize_word_output(
                 "normalized_input": normalized,
                 "selected_segmentation": selected_segmentation,
                 "ranking_strategy": strategy,
+                "fusion_method": fusion_method,
                 "candidates": candidates,
                 "component_rankings": component_rankings,
             }
@@ -2604,6 +2654,7 @@ def _file_job_status(
         "reranker_model": server_config["reranker_model"],
         "reranker_revision": server_config.get("reranker_revision"),
         "ranking_strategy": run_options["ranking_strategy"],
+        "fusion_method": run_options.get("fusion_method", "top2"),
     }
 
 
@@ -3119,6 +3170,9 @@ def segment_hashtags(
     ranking_strategy: RankingStrategy = "auto",
     alpha: float = 0.222,
     beta: float = 0.111,
+    fusion_method: FusionMethod = "top2",
+    rrf_k: float = 60,
+    fusion_weights: dict[str, float] | None = None,
     lower: bool = False,
     remove_hashtag: bool = True,
     hashtag_character: str = "#",
@@ -3156,6 +3210,9 @@ def segment_hashtags(
         beta,
         max_candidates,
         hashtag_character,
+        fusion_method,
+        rrf_k,
+        fusion_weights,
     )
     _require_models_configured()
     strategy = _resolve_ranking_strategy(ranking_strategy)
@@ -3179,6 +3236,9 @@ def segment_hashtags(
             steps=steps,
             alpha=alpha,
             beta=beta,
+            fusion_method=fusion_method,
+            rrf_k=rrf_k,
+            fusion_weights=fusion_weights,
             strategy=strategy,
             preprocessing_kwargs={
                 "lower": lower,
@@ -3194,6 +3254,7 @@ def segment_hashtags(
             strategy,
             max_candidates,
             include_component_rankings,
+            fusion_method,
         ),
         "models": _selected_models_payload(),
     }
@@ -3211,6 +3272,9 @@ def start_hashtag_file_job(
     ranking_strategy: RankingStrategy = "auto",
     alpha: float = 0.222,
     beta: float = 0.111,
+    fusion_method: FusionMethod = "top2",
+    rrf_k: float = 60,
+    fusion_weights: dict[str, float] | None = None,
     lower: bool = False,
     remove_hashtag: bool = True,
     hashtag_character: str = "#",
@@ -3263,6 +3327,9 @@ def start_hashtag_file_job(
         beta,
         max_candidates,
         hashtag_character,
+        fusion_method,
+        rrf_k,
+        fusion_weights,
     )
     _require_models_configured()
     resolved_strategy = _resolve_ranking_strategy(ranking_strategy)
@@ -3305,6 +3372,13 @@ def start_hashtag_file_job(
         "ranking_strategy": resolved_strategy,
         "alpha": float(alpha),
         "beta": float(beta),
+        "fusion_method": fusion_method,
+        "rrf_k": float(rrf_k),
+        "fusion_weights": dict(
+            {"segmenter": 1.0, "reranker": 1.0}
+            if fusion_weights is None
+            else fusion_weights
+        ),
         "lower": lower,
         "remove_hashtag": remove_hashtag,
         "hashtag_character": hashtag_character,
@@ -3684,6 +3758,9 @@ def rank_candidates(
     ranking_strategy: RankingStrategy = "auto",
     alpha: float = 0.222,
     beta: float = 0.111,
+    fusion_method: FusionMethod = "top2",
+    rrf_k: float = 60,
+    fusion_weights: dict[str, float] | None = None,
     max_candidates: int = 5,
     include_component_rankings: bool = False,
 ) -> SegmentationsResult:
@@ -3708,6 +3785,7 @@ def rank_candidates(
     _validate_input_count(candidate_sets, "candidate_sets")
     _validate_finite(alpha, "alpha")
     _validate_finite(beta, "beta")
+    _validate_fusion_options(fusion_method, rrf_k, fusion_weights)
     _validate_max_candidates(max_candidates)
     strategy = _resolve_ranking_strategy(ranking_strategy)
 
@@ -3822,6 +3900,9 @@ def rank_candidates(
                 steps=5,
                 alpha=alpha,
                 beta=beta,
+                fusion_method=fusion_method,
+                rrf_k=rrf_k,
+                fusion_weights=fusion_weights,
                 strategy=strategy,
                 segmenter_run=combined_run,
                 preprocessing_kwargs={"remove_hashtag": False},
@@ -3833,6 +3914,7 @@ def rank_candidates(
             strategy,
             max_candidates,
             include_component_rankings,
+            fusion_method,
         )
         for item, result in zip(batch, serialized):
             results[item["index"]] = result

--- a/src/hashformers/segmenter/auto.py
+++ b/src/hashformers/segmenter/auto.py
@@ -69,6 +69,9 @@ class TransformerWordSegmenter(BaseWordSegmenter):
             steps: int = 5,
             alpha: float = 0.222,
             beta: float = 0.111,
+            fusion_method: str = "top2",
+            rrf_k: float = 60,
+            fusion_weights: dict = None,
             use_reranker: bool = True,
             return_ranks: bool = False):
 
@@ -77,15 +80,17 @@ class TransformerWordSegmenter(BaseWordSegmenter):
                 "steps": steps
             }
 
-            ensembler_kwargs = {
-                "alpha": alpha,
-                "beta": beta
-            }
+            ensembler_kwargs = (
+                {"rrf_k": rrf_k, "fusion_weights": fusion_weights}
+                if fusion_method == "rrf"
+                else {"alpha": alpha, "beta": beta}
+            )
 
             return super().segment(
                 word_list,
                 segmenter_kwargs=segmenter_kwargs,
                 ensembler_kwargs=ensembler_kwargs,
+                fusion_method=fusion_method,
                 use_reranker=use_reranker,
                 return_ranks=return_ranks
             )

--- a/src/hashformers/segmenter/data_structures.py
+++ b/src/hashformers/segmenter/data_structures.py
@@ -12,3 +12,4 @@ class WordSegmenterOutput:
     segmenter_rank: Union[pd.DataFrame, None] = None
     reranker_rank: Union[pd.DataFrame, None] = None
     ensemble_rank: Union[pd.DataFrame, None] = None
+    fusion_method: str = "top2"

--- a/src/hashformers/segmenter/segmenter.py
+++ b/src/hashformers/segmenter/segmenter.py
@@ -2,6 +2,7 @@ from hashformers.beamsearch.data_structures import enforce_prob_dict
 from typing import Any
 from hashformers.segmenter.base_segmenter import BaseSegmenter
 from hashformers.segmenter.data_structures import WordSegmenterOutput
+from hashformers.ensemble.rrf_fusion import ReciprocalRankFusionEnsembler
 
 
 class BaseWordSegmenter(BaseSegmenter):
@@ -76,6 +77,7 @@ class BaseWordSegmenter(BaseSegmenter):
             segmenter_kwargs: dict = {},
             ensembler_kwargs: dict = {},
             reranker_kwargs: dict = {},
+            fusion_method: str = "top2",
             use_reranker: bool = True,
             use_ensembler: bool = True,
             return_ranks: bool = False) -> Any :
@@ -115,8 +117,16 @@ class BaseWordSegmenter(BaseSegmenter):
         if use_reranker and self.reranker_model:
             reranker_run = self.reranker_model.rerank(segmenter_run, **reranker_kwargs)
 
+        if fusion_method not in {"top2", "rrf"}:
+            raise ValueError("fusion_method must be top2 or rrf")
+
         if use_reranker and self.reranker_model and use_ensembler and self.ensembler:
-            ensemble_prob_dict = self.ensembler.run(
+            ensembler = (
+                ReciprocalRankFusionEnsembler()
+                if fusion_method == "rrf"
+                else self.ensembler
+            )
+            ensemble_prob_dict = ensembler.run(
                 segmenter_run,
                 reranker_run,
                 **ensembler_kwargs
@@ -155,5 +165,6 @@ class BaseWordSegmenter(BaseSegmenter):
                 segmenter_rank=segmenter_df,
                 reranker_rank=reranker_df,
                 ensemble_rank=ensembler_df,
-                output=segs
+                output=segs,
+                fusion_method=fusion_method,
             )

--- a/tests/test_rrf_fusion.py
+++ b/tests/test_rrf_fusion.py
@@ -1,0 +1,75 @@
+import math
+
+import pytest
+
+from hashformers.beamsearch.data_structures import ProbabilityDictionary
+from hashformers.ensemble.rrf_fusion import (
+    ReciprocalRankFusionEnsembler,
+    reciprocal_rank_fusion,
+)
+
+
+def test_known_rrf_scores_and_full_list_order():
+    segmenter = ProbabilityDictionary({"ab": 1.0, "a b": 2.0, "a  b": 3.0})
+    reranker = ProbabilityDictionary({"a  b": 10.0, "ab": 20.0, "a b": 30.0})
+
+    result = reciprocal_rank_fusion([segmenter, reranker], rrf_k=60)
+
+    assert list(result.dictionary) == ["ab", "a  b", "a b"]
+    assert result.dictionary["ab"] == pytest.approx(-(1 / 61 + 1 / 62))
+    assert len(result.dictionary) == 3
+
+
+def test_rrf_can_select_candidate_outside_segmenter_top_two():
+    segmenter = {"abc": 1.0, "a bc": 2.0, "ab c": 3.0}
+    reranker = {"ab c": 1.0, "abc": 2.0, "a bc": 3.0}
+
+    result = ReciprocalRankFusionEnsembler().run(
+        segmenter,
+        reranker,
+        rrf_k=0,
+        fusion_weights={"segmenter": 1.0, "reranker": 2.0},
+    )
+
+    assert next(iter(result.get_top_k(k=1))) == "ab c"
+
+
+def test_rrf_depends_on_rank_not_score_magnitude():
+    first = reciprocal_rank_fusion(
+        [{"abc": 1.0, "a bc": 2.0}, {"a bc": 3.0, "abc": 4.0}]
+    )
+    scaled = reciprocal_rank_fusion(
+        [{"abc": -1000.0, "a bc": 1e20}, {"a bc": -5.0, "abc": 99.0}]
+    )
+    assert list(first.dictionary) == list(scaled.dictionary)
+
+
+def test_competition_ties_use_component_then_stable_order():
+    result = reciprocal_rank_fusion(
+        [{"abc": 1.0, "a bc": 1.0}, {"a bc": 2.0, "abc": 2.0}],
+        rrf_k=0,
+    )
+    assert list(result.dictionary) == ["abc", "a bc"]
+
+
+@pytest.mark.parametrize(
+    ("rrf_k", "weights"),
+    [
+        (-1, [1.0, 1.0]),
+        (math.inf, [1.0, 1.0]),
+        (60, [-1.0, 1.0]),
+        (60, [0.0, 0.0]),
+        (60, [math.nan, 1.0]),
+    ],
+)
+def test_invalid_options(rrf_k, weights):
+    with pytest.raises(ValueError):
+        reciprocal_rank_fusion([{"abc": 1.0}, {"abc": 2.0}], weights, rrf_k)
+
+
+def test_union_includes_candidates_missing_from_a_component():
+    result = reciprocal_rank_fusion(
+        [{"abc": 1.0}, {"abc": 1.0, "a bc": 2.0}],
+        rrf_k=0,
+    )
+    assert set(result.dictionary) == {"abc", "a bc"}


### PR DESCRIPTION
## Summary

- add opt-in full-list weighted reciprocal rank fusion while preserving top-2 as the default
- expose RRF options through the Python API, interactive MCP tools, precomputed candidate ranking, and resumable file jobs
- preserve stable competition-rank and fused-tie semantics, including backward-compatible checkpoint metadata

## Root cause

The existing ensemble projected reranker scores onto only the segmenter's top two candidates, even though both component rankings retained the complete candidate set. That prevented the ensemble from selecting useful hypotheses below rank two.

## Impact

Callers can now select `fusion_method="rrf"`, configure `rrf_k` and component weights, and receive a complete fused ranking before response serialization limits are applied. Existing callers continue to use the tuned top-2 score-gap behavior.

## Validation

- `.venv-mcp/bin/python -m pytest -q tests/test_rrf_fusion.py tests/test_segmenter.py`
- `.venv-mcp/bin/python -m pytest -q tests/test_mcp_server.py`
- `.venv-mcp/bin/python -m pytest -q`
- `git diff --check`

Closes #82