### PR TITLE
Streamline README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,10 @@ claude mcp add --transport stdio --scope user hashformers -- \
 
 #### Segment Hashtags Interactively
 
-Call the `segment_hashtags` MCP tool:
+Ask the agent directly:
 
-```text
-segment_hashtags({
-  "hashtags": ["#weneedanationalpark", "#icecold"],
-  "max_candidates": 3
-})
-```
+> Use Hashformers to segment `#weneedanationalpark` and `#icecold`. Return up
+> to three candidates for each hashtag.
 
 #### Process Large Files
 
@@ -103,18 +99,11 @@ codex mcp add hashformers -- hashformers-mcp \
   --file-root /path/to/project
 ```
 
-Then start a resumable job and continue it until `status` is `completed`:
+Then ask the agent to run the resumable workflow:
 
-```text
-start_hashtag_file_job({
-  "input_path": "/path/to/project/hashtags.csv",
-  "output_path": "/path/to/project/segmented.jsonl"
-})
-
-continue_hashtag_file_job({
-  "job_path": "/path/to/project/segmented.jsonl.job.sqlite3"
-})
-```
+> Use Hashformers to segment the hashtags in
+> `/path/to/project/hashtags.csv`. Save the results to
+> `/path/to/project/segmented.jsonl` and continue until the job is complete.
 
 #### Select a Model for an Unknown Language
 
@@ -127,14 +116,8 @@ codex mcp add hashformers -- hashformers-mcp \
   --file-root /path/to/project
 ```
 
-```text
-sample_hashtag_file({"input_path": "/path/to/project/hashtags.csv"})
-discover_huggingface_models({"language": "tr", "role": "segmenter"})
-configure_models({
-  "segmenter_model": "MODEL_ID_FROM_DISCOVERY",
-  "segmenter_revision": "REVISION_FROM_DISCOVERY"
-})
-```
+> Sample `/path/to/project/hashtags.csv`, identify its language, select a
+> compatible public Hugging Face model, and segment the file with Hashformers.
 
 #### Install the Agent Skill
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,6 @@ print(segmentations)
 # ['we need a national park', 'ice cold']
 ```
 
-The default search uses `topk=5` and `steps=5` for interactive performance.
-For a wider search, use `ws.segment(inputs, topk=20, steps=13)`. Inference
-batches default to 64 candidates and can be configured when constructing the
-segmenter.
-
 For bulk CUDA workloads, opt into adaptive scorer microbatching independently
 for beam search and reranking:
 
@@ -64,22 +59,44 @@ ws = WordSegmenter(
 )
 ```
 
-Automatic mode starts at 64, tries geometrically larger full microbatches, and
-keeps a larger size only when synchronized candidate throughput improves while
-at least 20% of CUDA memory remains free. It backs off and retries the same
-candidates after a CUDA out-of-memory error. The selected size is cached only
-for that scorer and process; the segmenter and reranker therefore tune
-independently. Small calls do not trigger growth, and CPU execution uses the
-safe starting size without CUDA tuning. Inspect
-`ws.get_segmenter().batch_telemetry` (or `ws.get_reranker().batch_telemetry`)
-for the configured and effective sizes, tuning state, throughput, memory, and
-OOM backoff count.
+### MCP and Agent Skill
 
-This controller targets bulk candidate throughput, not a particular reported
-GPU-utilization percentage. CUDA utilization is sampled too coarsely to be the
-control signal for short beam-search scorer calls. Keep an explicit integer
-batch size, which remains the default, for predictable shared-GPU memory or
-latency.
+Install and start the optional local MCP server:
+
+```bash
+pip install "hashformers[mcp]"
+hashformers-mcp \
+  --model distilgpt2 \
+  --batch-size auto \
+  --file-root /path/to/project
+```
+
+Add it to Codex or Claude Code:
+
+```bash
+codex mcp add hashformers -- hashformers-mcp --model distilgpt2
+claude mcp add --transport stdio --scope user hashformers -- \
+  hashformers-mcp --model distilgpt2
+```
+
+Use `segment_hashtags` for interactive requests. For large text, CSV, or JSON
+Lines datasets, give the agent a local path and use `start_hashtag_file_job`
+followed by `continue_hashtag_file_job`; this keeps the dataset out of the
+agent's context and provides resumable checkpoints. If the language is unknown,
+start the server with `--defer-model-selection` so the agent can sample the file
+and choose a suitable public Hugging Face model before segmentation.
+
+The repository includes a `segment-hashtags` Agent Skill. Install it globally
+for Codex or Claude Code with:
+
+```bash
+mkdir -p ~/.agents/skills ~/.claude/skills
+cp -R .agents/skills/segment-hashtags ~/.agents/skills/
+cp -R .agents/skills/segment-hashtags ~/.claude/skills/
+```
+
+Run `hashformers-mcp --help` for all model, reranker, device, and file-access
+options.
 
 ### Using Language-Specific Models
 
@@ -116,160 +133,34 @@ Install with spaCy support:
 pip install hashformers[spacy]
 ```
 
-### MCP and Agent Skill
-
-Install the optional local MCP server on Python 3.10 or newer:
-
-```bash
-pip install "hashformers[mcp]"
-```
-
-The core `pip install hashformers` installation does not include the MCP SDK.
-Start the server over stdio with the same model settings accepted by the Python
-API:
-
-```bash
-hashformers-mcp \
-  --model distilgpt2 \
-  --batch-size auto \
-  --max-batch-size 512 \
-  --file-root /path/to/project
-```
-
-When the language is not known until an agent sees the request, start the same
-server in explicitly authorized deferred-selection mode:
-
-```bash
-hashformers-mcp \
-  --defer-model-selection \
-  --file-root /path/to/project
-```
-
-That process starts without selecting, downloading, or loading a Transformer.
-The agent can inspect at most 20 local examples with `sample_hashtag_file`,
-infer and report a language and confidence, obtain a bounded public-model
-shortlist with `discover_huggingface_models`, and make one `configure_models`
-call. Configuration anonymously re-fetches both repositories, rejects private,
-gated, over-size, unsupported, or custom-code models, and requires the exact
-Hub commit SHA returned by discovery. The first later inference downloads that
-pinned revision lazily. Identical configuration retries are safe; selecting a
-different model requires restarting the server.
-
-The default Hub ceilings are one billion parameters and 5 GB of selected pinned
-snapshot files. Operators can lower them with `--max-model-parameters` and
-`--max-model-size-bytes`. Deferred selection is the operator's authorization
-for its single remote selection and download; ordinary startup does not allow
-callers to change models.
-
-Optional startup flags configure the segmenter model and scorer type, device,
-and batch size. Supplying `--reranker-model` enables reranker-only and ensemble
-selection, with corresponding model-type, device, and batch-size flags. Run
-`hashformers-mcp --help` for the complete list. Models are loaded lazily and
-reused for the life of the process; `--device auto` selects CUDA when available
-and otherwise uses CPU. `--batch-size auto` and
-`--reranker-batch-size auto` opt the two scorers into independent adaptive
-microbatching; bound them with `--max-batch-size` and
-`--reranker-max-batch-size`. File-job tools are restricted to the server
-working directory by default; repeat `--file-root` to authorize other
-directories.
-File jobs currently require Linux descriptor-backed filesystem support through
-`/proc/self/fd`; interactive segmentation, model discovery/configuration, and
-candidate ranking remain available on other platforms.
-
-MCP clients normally launch that command for you. For example, configure Codex
-or Claude Code with:
-
-```bash
-codex mcp add hashformers -- hashformers-mcp --model distilgpt2
-claude mcp add --transport stdio --scope user hashformers -- \
-  hashformers-mcp --model distilgpt2
-```
-
-The server exposes the complete user-facing segmentation workflow:
-
-| Tool | Purpose |
-|------|---------|
-| `sample_hashtag_file` | Return at most 20 distinct reservoir-sampled hashtags and compact text, CSV, or JSON Lines metadata without copying the dataset into agent context. |
-| `discover_huggingface_models` | Return a deterministic, hard-capped shortlist of anonymously validated public Transformers models for a language and role. |
-| `configure_models` | Validate and publish one segmenter and optional reranker at exact Hub revisions when deferred selection was authorized at startup. |
-| `segment_hashtags` | Run Transformer beam search with configurable search depth, preprocessing, reranker or ensemble selection, and component rankings. |
-| `start_hashtag_file_job` | Index and deduplicate text, CSV, or JSON Lines locally without loading a model or placing the dataset in agent context. |
-| `continue_hashtag_file_job` | Process and atomically checkpoint one bounded batch of a file job; repeat until completion. |
-| `rank_candidates` | Select, rerank, or ensemble precomputed hypotheses without rerunning beam search. |
-
-Hashformers intentionally operates on hashtags rather than complete social
-posts. Applications that process full text should extract hashtags, call
-`segment_hashtags`, and perform replacements in application code. Generic
-regex substitution belongs in the caller or a dedicated heuristic splitter.
-
-`top_k` controls beam width while `max_candidates` independently limits the
-returned or written alternatives and is capped at 64. Model identity, devices,
-and GPU batch sizes are startup settings, except for the single exact-revision
-selection explicitly authorized by `--defer-model-selection`. The process
-retains at most one segmenter and one reranker. Interactive
-Transformer calls accept at most 64 inputs, `top_k` is capped at 64, and `steps`
-at 32. An aggregate expansion budget also rejects combinations of long inputs,
-wide beams, and deep searches that would still consume excessive memory. Larger
-inputs belong in the resumable file workflow.
-
-For large local datasets, pass only paths to `start_hashtag_file_job`. A text
-file contains one hashtag per line; CSV and JSON Lines inputs use the `hashtag`
-field by default. Repeatedly call `continue_hashtag_file_job` with the returned
-job path until its status is `completed`. Each call processes at most 64 unique
-hashtags by default and persists an atomic SQLite checkpoint, so client timeouts
-or restarts do not lose completed work. The final JSON Lines file preserves
-every source row and duplicate in order. Full inputs and results never consume
-agent-context tokens unless the user later asks the agent to open the output.
-The checkpoint contains the indexed inputs, so continuation does not repeatedly
-reread the source file. Existing outputs are never replaced unless the server
-was started with `--allow-file-overwrite` and the caller also passes
-`overwrite=true`.
-
-If the file language is unknown, call `sample_hashtag_file` before starting the
-job. Its deterministic hash-reservoir keeps memory and response size bounded
-independently of file length and returns only distinct samples, record count,
-format, and file size. No file contents or hashtags are sent to Hugging Face.
-File-job checkpoints, progress responses, interactive results, and final JSON
-Lines records preserve selected repository IDs and revisions. Deferred/pinned
-selection always records an exact revision; ordinary unpinned startup records
-`null`.
-
-This repository also includes the `segment-hashtags` Agent Skill at
-`.agents/skills/segment-hashtags`. Codex discovers it automatically when run
-from this repository. To make it available from every project, copy it to the
-user skill directory:
-
-```bash
-mkdir -p ~/.agents/skills
-cp -R .agents/skills/segment-hashtags ~/.agents/skills/
-```
-
-Claude Code uses a different discovery directory:
-
-```bash
-mkdir -p ~/.claude/skills
-cp -R .agents/skills/segment-hashtags ~/.claude/skills/
-```
-
-Restart the client if a newly created skill directory is not detected. The
-Skill chooses the appropriate MCP workflow and does not implement segmentation
-itself, so the MCP server must also be installed and configured.
-
 ## When to Use Hashformers?
 
-The table below describes the practical trade-offs between Hashformers,
-vocabulary-based splitters, and direct prompted generation. The January 2026
-Qwen2 result is a single historical configuration, not evidence about LLMs as a
-class. A pinned, auditable [Qwen3/Qwen2 fixed-protocol result](benchmarks/qwen/README.md)
-is published with raw generations, confidence intervals, invalid-output rates,
-and GPU measurements. It compares those two prompted configurations only; the
-Hashformers configurations were not rerun on the fixed manifest.
+Hashformers is designed to perform hashtag segmentation primarily on consumer
+GPUs. Its Transformer models often outperform language models that can run
+locally on GPUs at the same speed and scale, as shown in the
+[Qwen benchmark](benchmarks/qwen/README.md). It can be especially useful when
+both of the following are true:
 
-| Approach | Examples | Recommended When... | Notes |
-|----------|----------|---------------------|-------|
-| **Heuristic-based** | [SymSpell](https://github.com/wolfgarbe/SymSpell), [Ekphrasis](https://github.com/cbaziotis/ekphrasis), [WordNinja](https://github.com/keredson/wordninja), [Spiral (Ronin)](https://github.com/casics/spiral) | • **Scalability** is a primary requirement.<br><br>• The segmentation domain works well with a standard pre-built vocabulary. | Fast and efficient, but requires a pre-built vocabulary which can be limiting for niche domains or languages. |
-| **Hashformers** | [Hashformers](https://github.com/ruanchaves/hashformers) | • You want beam-search segmentation backed by a language model.<br><br>• You are working in a domain or language where an appropriate backbone is available, but compiling a manual vocabulary is too burdensome. | Accuracy and performance depend on the selected backbone, language, dataset, and search settings. |
-| **Prompted generative segmentation** | [Pinned Qwen benchmark and artifacts](benchmarks/qwen/README.md) | • You want to test a generative model under an explicit insertion-only output contract.<br><br>• Generation latency and invalid outputs are acceptable and measured. | The fixed-protocol run covers Qwen3-0.6B and Qwen2-0.5B-Instruct on one 280-record manifest. It does not establish a general size or quality threshold for prompted models. |
+- You have access to GPU compute. Even when renting a GPU, our
+  [cost projections](benchmarks/qwen/results/2026-08-03-colab-t4-fp16-v3/hosted-api-cost-projection.svg)
+  show Hashformers can be cheaper than major LLM providers at volumes of
+  roughly 120 hashtags or more.
+- Your hashtag segmentation domain is niche enough that heuristic methods such
+  as [SymSpell](https://github.com/wolfgarbe/SymSpell),
+  [Ekphrasis](https://github.com/cbaziotis/ekphrasis),
+  [WordNinja](https://github.com/keredson/wordninja), or
+  [Spiral (Ronin)](https://github.com/casics/spiral) are not accurate enough.
+
+Conversely, you may not wish to use Hashformers if:
+
+- Your domain is simple enough for a CPU-based heuristic method.
+- You are segmenting a low volume of hashtags, which may not justify using a
+  local GPU instead of a major LLM provider.
+- You are targeting maximum accuracy at any cost, in which case a cutting-edge
+  model from a major LLM provider may be a better fit.
+
+Hashformers therefore sits in the middle ground between heuristic methods and
+LLM APIs for users with consumer GPUs.
 
 ---
 
@@ -288,6 +179,8 @@ Hashformers was recognized as **state-of-the-art** for hashtag segmentation at [
 - [The problem of varying annotations to identify abusive language in social media content](https://www.cambridge.org/core/journals/natural-language-engineering/article/problem-of-varying-annotations-to-identify-abusive-language-in-social-media-content/B47FCCCEBF6EDF9C628DCC69EC5E0826)
 
 - [NUSS: An R package for mixed N-grams and unigram sequence segmentation](https://www.sciencedirect.com/science/article/pii/S2352711025002754#bbib0017)
+
+- [Hate Speech Detection in Turkish and Arabic Languages: A Comprehensive Study](https://arxiv.org/html/2607.00143v1)
 
 ### Citation
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,54 @@ claude mcp add --transport stdio --scope user hashformers -- \
   hashformers-mcp --model distilgpt2
 ```
 
-Use `segment_hashtags` for interactive requests. For large text, CSV, or JSON
-Lines datasets, give the agent a local path and use `start_hashtag_file_job`
-followed by `continue_hashtag_file_job`; this keeps the dataset out of the
-agent's context and provides resumable checkpoints. If the language is unknown,
-start the server with `--defer-model-selection` so the agent can sample the file
-and choose a suitable public Hugging Face model before segmentation.
+For interactive segmentation, call the `segment_hashtags` MCP tool:
+
+```text
+segment_hashtags({
+  "hashtags": ["#weneedanationalpark", "#icecold"],
+  "max_candidates": 3
+})
+```
+
+For a large text, CSV, or JSON Lines file, authorize its directory when adding
+the server:
+
+```bash
+codex mcp add hashformers -- hashformers-mcp \
+  --model distilgpt2 \
+  --file-root /path/to/project
+```
+
+Then start a resumable job and continue it until `status` is `completed`:
+
+```text
+start_hashtag_file_job({
+  "input_path": "/path/to/project/hashtags.csv",
+  "output_path": "/path/to/project/segmented.jsonl"
+})
+
+continue_hashtag_file_job({
+  "job_path": "/path/to/project/segmented.jsonl.job.sqlite3"
+})
+```
+
+If the language is unknown, let the agent sample the file and select a public
+Hugging Face model before segmentation:
+
+```bash
+codex mcp add hashformers -- hashformers-mcp \
+  --defer-model-selection \
+  --file-root /path/to/project
+```
+
+```text
+sample_hashtag_file({"input_path": "/path/to/project/hashtags.csv"})
+discover_huggingface_models({"language": "tr", "role": "segmenter"})
+configure_models({
+  "segmenter_model": "MODEL_ID_FROM_DISCOVERY",
+  "segmenter_revision": "REVISION_FROM_DISCOVERY"
+})
+```
 
 The repository includes a `segment-hashtags` Agent Skill. Install it globally
 for Codex or Claude Code with:
@@ -136,7 +178,7 @@ pip install hashformers[spacy]
 ## When to Use Hashformers?
 
 Hashformers is designed to perform hashtag segmentation primarily on consumer
-GPUs. Its Transformer models often outperform language models that can run
+GPUs. Its Transformer models often outperform LLMs that can run
 locally on GPUs at the same speed and scale, as shown in the
 [Qwen benchmark](benchmarks/qwen/README.md). It can be especially useful when
 both of the following are true:
@@ -213,6 +255,9 @@ pip install -e .
 
 ## 📖 Resources
 
+- [Qwen and Hashformers Benchmark (August 2026)](benchmarks/qwen/README.md)
+- [Hosted LLM API Cost Projections (August 2026)](benchmarks/qwen/results/2026-08-03-colab-t4-fp16-v3/hosted-api-cost-projection.svg)
+- [Benchmark Results and Reproducibility Artifacts (August 2026)](benchmarks/qwen/results/2026-08-03-colab-t4-fp16-v3/README.md)
 - [15 Datasets for Word Segmentation on the Hugging Face Hub](https://medium.com/@ruanchaves/15-datasets-for-word-segmentation-on-the-hugging-face-hub-4f24cb971e48)
 - [Benchmark Scripts](scripts/)
 - [Evaluation Report (January 2026)](tutorials/EVALUATION-January_2026.md)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb) [![PyPi license](https://badgen.net/pypi/license/pip/)](https://github.com/ruanchaves/hashformers/blob/master/LICENSE) [![stars](https://img.shields.io/github/stars/ruanchaves/hashformers)](https://github.com/ruanchaves/hashformers)
 
-**Hashformers** is a word segmentation library that fills a gap in the NLP ecosystem between heuristic-based splitters and LLM prompt-based segmentation. It can be used with any language model from the [Hugging Face Model Hub](https://huggingface.co/models), from auto-regressive models like GPT-2 to recent large language models (LLMs).
-
-**Hashformers** uses language models and a beam search algorithm to segment text without spaces into words. Historical benchmarks compare specific Hashformers, heuristic, and prompted-model configurations; their conclusions are scoped to the evaluated samples and settings.
+**Hashformers** uses language models and a beam search algorithm to segment text without spaces into words. It is a word segmentation library that fills a gap in the NLP ecosystem between heuristic-based splitters and LLM prompt-based segmentation. It can be used with any language model from the [Hugging Face Model Hub](https://huggingface.co/models), from auto-regressive models like GPT-2 to recent large language models (LLMs).
 
 <p align="center">
 <h3> <a href="https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb"> ✂️ Google Colab Tutorial </a> </h3>
@@ -61,6 +59,8 @@ ws = WordSegmenter(
 
 ### MCP and Agent Skill
 
+#### Install the MCP Server
+
 Install and start the optional local MCP server:
 
 ```bash
@@ -71,7 +71,9 @@ hashformers-mcp \
   --file-root /path/to/project
 ```
 
-Add it to Codex or Claude Code:
+#### Connect an MCP Client
+
+Add the server to Codex or Claude Code:
 
 ```bash
 codex mcp add hashformers -- hashformers-mcp --model distilgpt2
@@ -79,7 +81,9 @@ claude mcp add --transport stdio --scope user hashformers -- \
   hashformers-mcp --model distilgpt2
 ```
 
-For interactive segmentation, call the `segment_hashtags` MCP tool:
+#### Segment Hashtags Interactively
+
+Call the `segment_hashtags` MCP tool:
 
 ```text
 segment_hashtags({
@@ -87,6 +91,8 @@ segment_hashtags({
   "max_candidates": 3
 })
 ```
+
+#### Process Large Files
 
 For a large text, CSV, or JSON Lines file, authorize its directory when adding
 the server:
@@ -110,6 +116,8 @@ continue_hashtag_file_job({
 })
 ```
 
+#### Select a Model for an Unknown Language
+
 If the language is unknown, let the agent sample the file and select a public
 Hugging Face model before segmentation:
 
@@ -127,6 +135,8 @@ configure_models({
   "segmenter_revision": "REVISION_FROM_DISCOVERY"
 })
 ```
+
+#### Install the Agent Skill
 
 The repository includes a `segment-hashtags` Agent Skill. Install it globally
 for Codex or Claude Code with:


### PR DESCRIPTION
## Summary

- remove verbose search and adaptive-batching explanations from Basic Usage
- move MCP and Agent Skill directly below Basic Usage and replace internal detail with copyable interactive, file-job, and deferred-selection examples
- replace the comparison table with concise recommendations linked to the Qwen benchmark and hosted-cost projection
- add dated August 2026 benchmark, cost-projection, and reproducibility artifacts to Resources
- add *Hate Speech Detection in Turkish and Arabic Languages: A Comprehensive Study* to the papers list

## Why

The README had grown into exhaustive internal documentation. This revision focuses it on helping users decide when Hashformers fits and showing how to use its Python, MCP, and Agent Skill interfaces.

## Validation

- verified all local Markdown link targets exist
- verified the added paper title and URL against the arXiv record
- `git diff --check`