### PR TITLE
Showcase Hashformers benchmark results in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,40 @@
-# ✂️ hashformers
+# ✂️ Hashformers
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb) [![PyPi license](https://badgen.net/pypi/license/pip/)](https://github.com/ruanchaves/hashformers/blob/master/LICENSE) [![stars](https://img.shields.io/github/stars/ruanchaves/hashformers)](https://github.com/ruanchaves/hashformers)
+[![PyPI](https://img.shields.io/pypi/v/hashformers)](https://pypi.org/project/hashformers/)
+[![Python](https://img.shields.io/pypi/pyversions/hashformers)](https://pypi.org/project/hashformers/)
+[![License](https://img.shields.io/pypi/l/hashformers)](https://github.com/ruanchaves/hashformers/blob/master/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/ruanchaves/hashformers)](https://github.com/ruanchaves/hashformers)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb)
+[![Open the Codex and Claude Code MCP tutorial in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers_agents_mcp_tutorial.ipynb)
 
-**Hashformers** uses language models and a beam search algorithm to segment text without spaces into words. It is a word segmentation library that fills a gap in the NLP ecosystem between heuristic-based splitters and LLM prompt-based segmentation. It can be used with any language model from the [Hugging Face Model Hub](https://huggingface.co/models), from auto-regressive models like GPT-2 to recent large language models (LLMs).
+**Fast, local, multilingual hashtag and identifier segmentation using
+Transformer language models and beam search.**
 
-<p align="center">
-<h3> <a href="https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb"> ✂️ Google Colab Tutorial </a> </h3>
-</p>
+- **+37.5 percentage-point accuracy advantage** over Qwen3-0.6B on a
+  [fixed 280-item multilingual benchmark](benchmarks/qwen/README.md)
+- **14.1 hashtags/second** on a single NVIDIA T4
+- Available as a **Python library, spaCy component, MCP server, and Agent Skill**
+- Recognized as **state of the art at [LREC 2022](https://aclanthology.org/2022.lrec-1.782/)**
 
-<p align="center">
-<h3> <a href="https://github.com/ruanchaves/hashformers/blob/master/tutorials/EVALUATION-January_2026.md"> ✂️ Evaluation Report </a> </h3>
-</p>
+[Quick start](#-quick-start) · [Agent workflows](#mcp-and-agent-skill) ·
+[Benchmark](benchmarks/qwen/README.md) ·
+[Paper](https://aclanthology.org/2022.lrec-1.782/)
+
+Hashformers uses language models and a beam search algorithm to segment text
+without spaces into words. It fills a gap in the NLP ecosystem between
+heuristic-based splitters and LLM prompt-based segmentation, and it can use
+language models from the [Hugging Face Model Hub](https://huggingface.co/models).
+
+## Benchmark Snapshot
+
+[![Exact-match accuracy for Hashformers and Qwen configurations](docs/assets/hashformers-qwen-benchmark.svg)](benchmarks/qwen/README.md)
+
+On the fixed 280-record benchmark, Hashformers with DistilGPT2 reached 65.0%
+exact-match accuracy, exceeding Qwen3-0.6B by **37.5 percentage points**. The
+chart compares the published configurations and does not make a general claim
+about all LLMs. Hashformers and generative-model throughput measure different
+inference paths; see the [full protocol and artifacts](benchmarks/qwen/README.md)
+for the scoped interpretation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![License](https://img.shields.io/pypi/l/hashformers)](https://github.com/ruanchaves/hashformers/blob/master/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/ruanchaves/hashformers)](https://github.com/ruanchaves/hashformers)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb)
-[![Open the Codex and Claude Code MCP tutorial in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers_agents_mcp_tutorial.ipynb)
 
 **Fast, local, multilingual hashtag and identifier segmentation using
 Transformer language models and beam search.**
@@ -14,11 +13,16 @@ Transformer language models and beam search.**
   [fixed 280-item multilingual benchmark](benchmarks/qwen/README.md)
 - **14.1 hashtags/second** on a single NVIDIA T4
 - Available as a **Python library, spaCy component, MCP server, and Agent Skill**
-- Recognized as **state of the art at [LREC 2022](https://aclanthology.org/2022.lrec-1.782/)**
+- Introduced in the [original Hashformers paper](https://arxiv.org/abs/2112.03213)
+  and recognized as **state of the art at
+  [LREC 2022](https://aclanthology.org/2022.lrec-1.782/)**
 
-[Quick start](#-quick-start) · [Agent workflows](#mcp-and-agent-skill) ·
+[Quick start](#-quick-start) ·
+[Colab tutorial](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb) ·
+[Agent workflows](#mcp-and-agent-skill) ·
 [Benchmark](benchmarks/qwen/README.md) ·
-[Paper](https://aclanthology.org/2022.lrec-1.782/)
+[Hashformers paper](https://arxiv.org/abs/2112.03213) ·
+[LREC 2022 recognition](https://aclanthology.org/2022.lrec-1.782/)
 
 Hashformers uses language models and a beam search algorithm to segment text
 without spaces into words. It fills a gap in the NLP ecosystem between
@@ -194,32 +198,28 @@ pip install hashformers[spacy]
 
 ## When to Use Hashformers?
 
-Hashformers is designed to perform hashtag segmentation primarily on consumer
-GPUs. Its Transformer models often outperform LLMs that can run
-locally on GPUs at the same speed and scale, as shown in the
-[Qwen benchmark](benchmarks/qwen/README.md). It can be especially useful when
-both of the following are true:
+Hashformers occupies the middle ground between CPU heuristics and hosted LLM
+APIs: it provides model-backed segmentation while keeping inference local and
+scalable on consumer GPUs.
 
-- You have access to GPU compute. Even when renting a GPU, our
-  [cost projections](benchmarks/qwen/results/2026-08-03-colab-t4-fp16-v3/hosted-api-cost-projection.svg)
-  show Hashformers can be cheaper than major LLM providers at volumes of
-  roughly 120 hashtags or more.
-- Your hashtag segmentation domain is niche enough that heuristic methods such
-  as [SymSpell](https://github.com/wolfgarbe/SymSpell),
-  [Ekphrasis](https://github.com/cbaziotis/ekphrasis),
-  [WordNinja](https://github.com/keredson/wordninja), or
-  [Spiral (Ronin)](https://github.com/casics/spiral) are not accurate enough.
+| Approach | Compute | Domain adaptability | Local/private | Throughput | Agent integration |
+|---|---|---|---|---|---|
+| Heuristic splitters | CPU | Limited by their vocabulary and rules | Yes | High | Limited |
+| Hosted LLM APIs | Remote provider | Broad | Provider-dependent | Cost and rate-limit dependent | Provider-dependent |
+| **Hashformers** | GPU recommended | Selectable Hugging Face backbone | Yes | **14.1 hashtags/s on a T4** | **MCP and Agent Skill** |
 
-Conversely, you may not wish to use Hashformers if:
+Hashformers is a strong fit when you have access to GPU compute and work in a
+niche domain where [SymSpell](https://github.com/wolfgarbe/SymSpell),
+[Ekphrasis](https://github.com/cbaziotis/ekphrasis),
+[WordNinja](https://github.com/keredson/wordninja), or
+[Spiral (Ronin)](https://github.com/casics/spiral) is not accurate enough. The
+[cost projections](benchmarks/qwen/results/2026-08-03-colab-t4-fp16-v3/hosted-api-cost-projection.svg)
+show that even a rented GPU can become competitive with major LLM providers at
+moderate batch sizes.
 
-- Your domain is simple enough for a CPU-based heuristic method.
-- You are segmenting a low volume of hashtags, which may not justify using a
-  local GPU instead of a major LLM provider.
-- You are targeting maximum accuracy at any cost, in which case a cutting-edge
-  model from a major LLM provider may be a better fit.
-
-Hashformers therefore sits in the middle ground between heuristic methods and
-LLM APIs for users with consumer GPUs.
+For simple domains, a CPU heuristic may be the better choice. For low-volume
+jobs or maximum accuracy regardless of cost and privacy, a cutting-edge hosted
+LLM may be a better fit.
 
 ---
 

--- a/docs/assets/hashformers-qwen-benchmark.svg
+++ b/docs/assets/hashformers-qwen-benchmark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="310" viewBox="0 0 860 310" role="img" aria-labelledby="title description">
+  <title id="title">Exact-match accuracy benchmark</title>
+  <desc id="description">Hashformers with DistilGPT2 achieved 65.0 percent, Hashformers with GPT-2 achieved 64.6 percent, Qwen2-0.5B-Instruct achieved 37.9 percent, and Qwen3-0.6B achieved 27.5 percent.</desc>
+  <style>
+    .label { fill: #1f2328; font: 600 17px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .value { fill: #1f2328; font: 700 17px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .tick { fill: #656d76; font: 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .track { fill: #d0d7de; opacity: 0.45; }
+    .hashformers { fill: #1f883d; }
+    .qwen { fill: #8250df; }
+    @media (prefers-color-scheme: dark) {
+      .label, .value { fill: #f0f6fc; }
+      .tick { fill: #8c959f; }
+      .track { fill: #30363d; opacity: 1; }
+      .hashformers { fill: #3fb950; }
+      .qwen { fill: #a371f7; }
+    }
+  </style>
+
+  <text class="tick" x="260" y="20">0%</text>
+  <text class="tick" x="409" y="20">20%</text>
+  <text class="tick" x="558" y="20">40%</text>
+  <text class="tick" x="707" y="20">60%</text>
+
+  <text class="label" x="12" y="60">Hashformers + DistilGPT2</text>
+  <rect class="track" x="260" y="37" width="520" height="32" rx="6"/>
+  <rect class="hashformers" x="260" y="37" width="483" height="32" rx="6"/>
+  <text class="value" x="753" y="60">65.0%</text>
+
+  <text class="label" x="12" y="124">Hashformers + GPT-2</text>
+  <rect class="track" x="260" y="101" width="520" height="32" rx="6"/>
+  <rect class="hashformers" x="260" y="101" width="480" height="32" rx="6"/>
+  <text class="value" x="750" y="124">64.6%</text>
+
+  <text class="label" x="12" y="188">Qwen2-0.5B-Instruct</text>
+  <rect class="track" x="260" y="165" width="520" height="32" rx="6"/>
+  <rect class="qwen" x="260" y="165" width="281" height="32" rx="6"/>
+  <text class="value" x="551" y="188">37.9%</text>
+
+  <text class="label" x="12" y="252">Qwen3-0.6B</text>
+  <rect class="track" x="260" y="229" width="520" height="32" rx="6"/>
+  <rect class="qwen" x="260" y="229" width="204" height="32" rx="6"/>
+  <text class="value" x="474" y="252">27.5%</text>
+
+  <text class="tick" x="260" y="292">Exact-match accuracy on the fixed 280-item multilingual benchmark</text>
+</svg>


### PR DESCRIPTION
## Summary

- lead the README with a recruiter-friendly product statement and four evidence-backed highlights
- distinguish the original Hashformers paper from its later LREC 2022 state-of-the-art recognition
- restore an explicit Colab tutorial link and add navigation to agent workflows and benchmark evidence
- replace the incorrect license badge with Hashformers-specific PyPI, Python, and license badges
- add a compact accessible benchmark chart comparing the four published configurations
- rewrite “When to Use Hashformers?” as a scannable comparison table with concise decision guidance
- keep all benchmark and cost interpretations scoped to their published protocols

## Why

The strongest evidence of Hashformers' engineering quality and practical value was buried below the fold. This change makes benchmark performance, local throughput, integration surface, research provenance, and deployment tradeoffs visible and easy to scan while preserving the detailed documentation below.

## Validation

- verified every local README link resolves
- verified the SVG is well-formed XML
- verified benchmark values and the 37.5 percentage-point difference against the committed August 2026 benchmark artifacts
- `git diff --check`

## Follow-up

A real Claude Code demo GIF can be added separately once an authentic recording is available; this PR does not use a mocked agent interaction.