### PR TITLE
Add Colab tutorial for agent MCP workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/pypi/l/hashformers)](https://github.com/ruanchaves/hashformers/blob/master/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/ruanchaves/hashformers)](https://github.com/ruanchaves/hashformers)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb)
+[![Open the Codex and Claude Code MCP tutorial in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers_agents_mcp_tutorial.ipynb)
 
 **Fast, local, multilingual hashtag and identifier segmentation using
 Transformer language models and beam search.**
@@ -19,6 +20,7 @@ Transformer language models and beam search.**
 
 [Quick start](#-quick-start) ·
 [Colab tutorial](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers.ipynb) ·
+[Codex + Claude Code MCP Colab tutorial](https://colab.research.google.com/github/ruanchaves/hashformers/blob/master/hashformers_agents_mcp_tutorial.ipynb) ·
 [Agent workflows](#mcp-and-agent-skill) ·
 [Benchmark](benchmarks/qwen/README.md) ·
 [Hashformers paper](https://arxiv.org/abs/2112.03213) ·

--- a/hashformers_agents_mcp_tutorial.ipynb
+++ b/hashformers_agents_mcp_tutorial.ipynb
@@ -1,0 +1,1562 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dZGV7eakZpGZ"
+   },
+   "source": [
+    "# Hashformers MCP + Agent Skill with Codex and Claude Code\n",
+    "\n",
+    "This tutorial runs the Hashformers MCP server inside Google Colab and connects it to both [Codex CLI](https://learn.chatgpt.com/docs/developer-commands) and [Claude Code](https://code.claude.com/docs/en/overview). You will:\n",
+    "\n",
+    "1. clone Hashformers from GitHub and install `hashformers[mcp]` from that checkout;\n",
+    "2. install and authenticate Codex CLI and Claude Code;\n",
+    "3. install the repository's `segment-hashtags` Agent Skill;\n",
+    "4. register the local stdio MCP server with both clients; and\n",
+    "5. exercise the interactive, resumable-file, and deferred-model workflows described in the README.\n",
+    "\n",
+    "> **Runtime:** choose **Runtime → Change runtime type → T4 GPU** before running the notebook. Colab VMs are temporary; repeat the authentication cells after a runtime reset. Never paste API keys into a notebook that will be shared.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-3tW1iA3ZpGk"
+   },
+   "source": [
+    "## 1. Check the Colab runtime\n",
+    "\n",
+    "The agents themselves are command-line clients. Hashformers uses the Colab GPU when the MCP server loads the Transformer model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "A4A_k9p4ZpGl",
+    "outputId": "77c583c1-c659-4e34-e5b8-7505d7569799"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Python: 3.12.13\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args=['nvidia-smi', '--query-gpu=name,memory.total', '--format=csv,noheader'], returncode=0)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 1
+    }
+   ],
+   "source": [
+    "import platform\n",
+    "import subprocess\n",
+    "\n",
+    "print(\"Python:\", platform.python_version())\n",
+    "subprocess.run([\"node\", \"--version\"], check=True)\n",
+    "subprocess.run(\n",
+    "    [\"nvidia-smi\", \"--query-gpu=name,memory.total\", \"--format=csv,noheader\"],\n",
+    "    check=True,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zFO5a4_UZpGn"
+   },
+   "source": [
+    "## 2. Clone and install from Git\n",
+    "\n",
+    "For development validation, install Hashformers directly from the checked-out Git branch rather than PyPI. The MCP extra supplies the MCP SDK and the `hashformers-mcp` entry point. The saved output was captured from the feature branch used to validate this tutorial; the released cell defaults to `master`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ey9yI6W1ZpGp",
+    "outputId": "99a8d836-c119-4def-8710-e66b527d31f4"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Cloning into '/content/hashformers'...\n",
+      "remote: Enumerating objects: 3536, done.\u001b[K\n",
+      "remote: Counting objects: 100% (191/191), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (135/135), done.\u001b[K\n",
+      "remote: Total 3536 (delta 63), reused 95 (delta 52), pack-reused 3345 (from 2)\u001b[K\n",
+      "Receiving objects: 100% (3536/3536), 24.67 MiB | 17.96 MiB/s, done.\n",
+      "Resolving deltas: 100% (2188/2188), done.\n",
+      "/content/hashformers\n",
+      "agent/colab-agent-mcp-tutorial\n",
+      "4ac60e9269dd7e8dc1ea1a84c45b375319df4c3e\n",
+      "## \u001b[32magent/colab-agent-mcp-tutorial\u001b[m...\u001b[31morigin/agent/colab-agent-mcp-tutorial\u001b[m\n"
+     ]
+    }
+   ],
+   "source": [
+    "REPOSITORY = \"https://github.com/ruanchaves/hashformers.git\"\n",
+    "BRANCH = \"master\"  # Use your working branch when validating a PR.\n",
+    "\n",
+    "!git clone --branch {BRANCH} --single-branch {REPOSITORY} /content/hashformers\n",
+    "%cd /content/hashformers\n",
+    "!git rev-parse --abbrev-ref HEAD\n",
+    "!git rev-parse HEAD\n",
+    "!git status --short --branch\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "0f-IXwiaZpGr",
+    "outputId": "dffcc321-32fb-4b7f-bd87-4121682fa278"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m350.0/350.0 kB\u001b[0m \u001b[31m11.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m69.6/69.6 kB\u001b[0m \u001b[31m7.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m41.7/41.7 kB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m51.7/51.7 kB\u001b[0m \u001b[31m5.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hName: hashformers\n",
+      "Version: 3.0.0\n",
+      "Editable project location: /content/hashformers/src\n",
+      "usage: hashformers-mcp [-h] [--defer-model-selection]\n",
+      "                       [--model SEGMENTER_MODEL]\n",
+      "                       [--segmenter-model-type SEGMENTER_MODEL_TYPE]\n",
+      "                       [--device SEGMENTER_DEVICE]\n",
+      "                       [--batch-size SEGMENTER_BATCH_SIZE]\n",
+      "                       [--max-batch-size SEGMENTER_MAX_BATCH_SIZE]\n",
+      "                       [--reranker-model RERANKER_MODEL]\n",
+      "                       [--reranker-model-type RERANKER_MODEL_TYPE]\n",
+      "                       [--reranker-device RERANKER_DEVICE]\n",
+      "                       [--reranker-batch-size RERANKER_BATCH_SIZE]\n",
+      "                       [--reranker-max-batch-size RERANKER_MAX_BATCH_SIZE]\n",
+      "                       [--file-root FILE_ROOT] [--allow-file-overwrite]\n",
+      "                       [--max-model-parameters MAX_MODEL_PARAMETERS]\n",
+      "                       [--max-model-size-bytes MAX_MODEL_SIZE_BYTES]\n",
+      "\n",
+      "Run the Hashformers MCP server over stdio.\n",
+      "\n",
+      "options:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --defer-model-selection\n",
+      "                        Start without loading or selecting a model and\n",
+      "                        authorize one configure_models call for validated\n",
+      "                        public Hub revisions.\n",
+      "  --model SEGMENTER_MODEL, --segmenter-model SEGMENTER_MODEL\n",
+      "                        Hugging Face model name or local path used for beam\n",
+      "                        search.\n",
+      "  --segmenter-model-type SEGMENTER_MODEL_TYPE\n",
+      "                        Hashformers scorer type used for beam search.\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python -m pip install -q -e \".[mcp]\"\n",
+    "!python -m pip show hashformers | grep -E '^(Name|Version|Editable project location):'\n",
+    "!hashformers-mcp --help | sed -n '1,28p'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yyHXw_apZpGt"
+   },
+   "source": [
+    "## 3. Install Codex CLI and Claude Code\n",
+    "\n",
+    "Both clients are installed in the Colab VM. The commands below use their supported npm packages, which is convenient in Colab's preconfigured Node.js environment. See the current [Codex authentication guide](https://learn.chatgpt.com/docs/auth) and [Claude Code setup guide](https://code.claude.com/docs/en/installation) if a later CLI release changes the flow.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "q49cc-oeZpGw",
+    "outputId": "c7e4a5a6-2eed-4e27-8d87-a8a2c07eebb0"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K⠧\u001b[1G\u001b[0K⠇\u001b[1G\u001b[0K⠏\u001b[1G\u001b[0K⠋\u001b[1G\u001b[0K⠙\u001b[1G\u001b[0K⠹\u001b[1G\u001b[0K⠸\u001b[1G\u001b[0K⠼\u001b[1G\u001b[0K⠴\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K\n",
+      "added 4 packages in 10s\n",
+      "\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0K\u001b[1mnpm\u001b[22m \u001b[96mnotice\u001b[39m\n",
+      "\u001b[1mnpm\u001b[22m \u001b[96mnotice\u001b[39m New \u001b[31mmajor\u001b[39m version of npm available! \u001b[31m10.8.2\u001b[39m -> \u001b[34m12.0.2\u001b[39m\n",
+      "\u001b[1mnpm\u001b[22m \u001b[96mnotice\u001b[39m Changelog: \u001b[34mhttps://github.com/npm/cli/releases/tag/v12.0.2\u001b[39m\n",
+      "\u001b[1mnpm\u001b[22m \u001b[96mnotice\u001b[39m To update run: \u001b[4mnpm install -g npm@12.0.2\u001b[24m\n",
+      "\u001b[1mnpm\u001b[22m \u001b[96mnotice\u001b[39m\n",
+      "\u001b[1G\u001b[0K⠦\u001b[1G\u001b[0Kcodex-cli 0.146.0\n",
+      "2.1.197 (Claude Code)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!npm install -g @openai/codex @anthropic-ai/claude-code\n",
+    "!codex --version\n",
+    "!claude --version\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-3VY3o7uZpGz"
+   },
+   "source": [
+    "## 4. Authenticate the two clients\n",
+    "\n",
+    "Run these cells **one at a time**. For Codex, open the printed device-login URL and enter the one-time code. For Claude Code, open the printed URL; if the browser displays a login code instead of redirecting to Colab, paste that code into the cell prompt.\n",
+    "\n",
+    "> The published copy intentionally clears the transient login-cell outputs. The following status check records only whether each login succeeded.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "clear-auth-output"
+    ],
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "L6Jl0JVGZpG1",
+    "outputId": "723b9de7-24d5-470d-e9f6-713ba4fafd95"
+   },
+   "outputs": [],
+   "source": [
+    "!codex login --device-auth\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "clear-auth-output"
+    ],
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "1Uuk3Tb1ZpG2",
+    "outputId": "e3115ea6-ca09-435f-c021-f7e690f6c95f"
+   },
+   "outputs": [],
+   "source": [
+    "import pexpect\n",
+    "\n",
+    "claude_login = pexpect.spawn(\n",
+    "    \"claude\", [\"auth\", \"login\"], encoding=\"utf-8\", timeout=300\n",
+    ")\n",
+    "claude_login.setecho(False)\n",
+    "claude_login.expect(r\"If the browser didn't open, visit: (https://\\S+)\")\n",
+    "authorization_url = claude_login.match.group(1)\n",
+    "print(\"Open this URL in your browser:\\n\", authorization_url)\n",
+    "claude_login.expect(\"Paste code here if prompted >\")\n",
+    "authorization_code = input(\"Paste the code from the browser here: \")\n",
+    "claude_login.sendline(authorization_code)\n",
+    "claude_login.expect(pexpect.EOF)\n",
+    "claude_login.close()\n",
+    "if claude_login.exitstatus != 0:\n",
+    "    raise RuntimeError(\"Claude Code authentication failed\")\n",
+    "print(\"Claude Code login completed\")\n",
+    "del authorization_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "AgrBSbW4ZpG3",
+    "outputId": "20083eb4-e531-4532-850b-c3e5dd218b0f"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Codex authenticated: True\n",
+      "Claude Code authenticated: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "auth_checks = {\n",
+    "    \"Codex\": [\"codex\", \"login\", \"status\"],\n",
+    "    \"Claude Code\": [\"claude\", \"auth\", \"status\"],\n",
+    "}\n",
+    "for client, command in auth_checks.items():\n",
+    "    completed = subprocess.run(\n",
+    "        command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL\n",
+    "    )\n",
+    "    print(f\"{client} authenticated: {completed.returncode == 0}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t5x24aadZpG4"
+   },
+   "source": [
+    "## 5. Install the Agent Skill\n",
+    "\n",
+    "The MCP server provides bounded tools and enforces their contracts. The `segment-hashtags` skill teaches each agent when and how to combine those tools. Codex discovers personal skills under `~/.agents/skills`; Claude Code uses `~/.claude/skills`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "lRoBJ6-bZpG5",
+    "outputId": "68406721-c60e-4c82-ecd7-3e2f17570101"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Codex skill installed\n",
+      "Claude Code skill installed\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mkdir -p ~/.agents/skills ~/.claude/skills\n",
+    "!cp -R .agents/skills/segment-hashtags ~/.agents/skills/\n",
+    "!cp -R .agents/skills/segment-hashtags ~/.claude/skills/\n",
+    "!test -f ~/.agents/skills/segment-hashtags/SKILL.md && echo \"Codex skill installed\"\n",
+    "!test -f ~/.claude/skills/segment-hashtags/SKILL.md && echo \"Claude Code skill installed\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lPbF5RnlZpG5"
+   },
+   "source": [
+    "## 6. Register the Hashformers MCP server\n",
+    "\n",
+    "These are the README's stdio registration commands. This tutorial also authorizes one explicit Colab directory for the resumable file example and enables automatic CUDA microbatch tuning. The clients start `hashformers-mcp` when an agent session begins.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "YWfmcN_uZpG6",
+    "outputId": "c49760e2-0910-49bb-e16a-51d63423478d"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Added global MCP server 'hashformers'.\n",
+      "Added stdio MCP server hashformers with command: hashformers-mcp --model distilgpt2 --batch-size auto --file-root /content/hashformers/tutorial_data to user config\n",
+      "File modified: /root/.claude.json\n",
+      "\u001b[?25h"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "DATA_DIRECTORY = Path(\"/content/hashformers/tutorial_data\")\n",
+    "DATA_DIRECTORY.mkdir(exist_ok=True)\n",
+    "\n",
+    "!codex mcp add hashformers -- hashformers-mcp --model distilgpt2 --batch-size auto --file-root {DATA_DIRECTORY}\n",
+    "!claude mcp add --transport stdio --scope user hashformers -- hashformers-mcp --model distilgpt2 --batch-size auto --file-root {DATA_DIRECTORY}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "A5gKMhkHZpG7",
+    "outputId": "a17a0986-56ec-4eba-d812-8bfba377e6d0"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Name         Command          Args                                                                                 Env  Cwd  Status   Auth       \n",
+      "hashformers  hashformers-mcp  --model distilgpt2 --batch-size auto --file-root /content/hashformers/tutorial_data  -    -    enabled  Unsupported\n",
+      "\u001b7\u001b[r\u001b8\u001b[?25hhashformers:\n",
+      "\u001b[3GScope:\u001b[10GUser\u001b[15Gconfig\u001b[22G(available\u001b[33Gin\u001b[36Gall\u001b[40Gyour\u001b[45Gprojects)\n",
+      "\u001b[3GStatus:\u001b[11G✔\u001b[13GConnected\n",
+      "\u001b[3GType:\u001b[9Gstdio\n",
+      "\u001b[3GCommand:\u001b[12Ghashformers-mcp\n",
+      "\u001b[3GArgs:\u001b[9G--model\u001b[17Gdistilgpt2\u001b[28G--batch-size\u001b[41Gauto\u001b[46G--file-root\n",
+      "/content/hashformers/tutorial_data\n",
+      "\u001b[3GEnvironment:\n",
+      "\n",
+      "To\u001b[4Gremove\u001b[11Gthis\u001b[16Gserver,\u001b[24Grun:\u001b[29Gclaude\u001b[36Gmcp\u001b[40Gremove\u001b[47Ghashformers\u001b[59G-s\u001b[62Guser\n",
+      "\u001b[?25h\u001b[?1006l\u001b[?1003l\u001b[?1002l\u001b[?1000l\u001b(B\u000f\u001b[>4m\u001b[<u\u001b[?1004l\u001b[?2031l\u001b[?2004l\u001b[?25h\u001b7\u001b[r\u001b8\u001b[?25h\u001b[?1006l\u001b[?1003l\u001b[?1002l\u001b[?1000l\u001b(B\u000f\u001b[>4m\u001b[<u\u001b[?1004l\u001b[?2031l\u001b[?2004l\u001b[?25h\u001b7\u001b[r\u001b8\u001b]0;\u0007\u001b[?25h"
+     ]
+    }
+   ],
+   "source": [
+    "!codex mcp list\n",
+    "!claude mcp get hashformers\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RIv9w5IAZpG7"
+   },
+   "source": [
+    "## 7. Segment hashtags interactively\n",
+    "\n",
+    "First ask Codex, then Claude Code, to use the installed skill and the MCP tool. The first model-backed call downloads and caches `distilgpt2`; later calls reuse the Hugging Face cache.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "0xa7kIP4ZpG8",
+    "outputId": "ad775aab-2101-4b15-d74d-36ba4e76881c"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "OpenAI Codex v0.146.0\n",
+      "--------\n",
+      "\u001b[1mworkdir:\u001b[0m /content/hashformers\n",
+      "\u001b[1mmodel:\u001b[0m gpt-5.6-sol\n",
+      "\u001b[1mprovider:\u001b[0m openai\n",
+      "\u001b[1mapproval:\u001b[0m never\n",
+      "\u001b[1msandbox:\u001b[0m read-only\n",
+      "\u001b[1mreasoning effort:\u001b[0m none\n",
+      "\u001b[1mreasoning summaries:\u001b[0m none\n",
+      "\u001b[1msession id:\u001b[0m 019fcc77-8e53-7c10-b8fa-aa7a53cc2ebb\n",
+      "--------\n",
+      "\u001b[36muser\u001b[0m\n",
+      "Use the segment-hashtags skill and the Hashformers MCP server to segment #weneedanationalpark and #icecold. Return up to three candidates for each hashtag. Do not estimate the segmentations yourself.\n",
+      "\u001b[1m\u001b[33mwarning:\u001b[0m\u001b[0m Codex could not find bubblewrap on PATH. Install bubblewrap with your OS package manager. See the sandbox prerequisites: https://developers.openai.com/codex/concepts/sandboxing#prerequisites. Codex will use the bundled bubblewrap in the meantime.\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "I’m using the segment-hashtags skill because it provides the MCP-only workflow for generating and ranking candidates without guessing locally.\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc \"sed -n '1,240p' /content/hashformers/.agents/skills/segment-hashtags/SKILL.md\"\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "---\n",
+      "name: segment-hashtags\n",
+      "description: Segment hashtags, sample and process hashtag files without copying their contents into agent context, discover and configure language-appropriate public Hub models, and rank precomputed segmentation candidates with the Hashformers MCP server. Use when a user asks to split or decompound hashtags, run bulk local segmentation, select a model for an unknown language, compare candidates, rerank hypotheses, or inspect component scores.\n",
+      "---\n",
+      "\n",
+      "# Segment with Hashformers\n",
+      "\n",
+      "Use the configured Hashformers MCP server. Never reproduce the algorithm, load a\n",
+      "model directly, or guess segmentations when the tools are unavailable.\n",
+      "\n",
+      "## Workflow\n",
+      "\n",
+      "1. Confirm that the required Hashformers MCP tool is available. If it is not,\n",
+      "   explain that `hashformers[mcp]` must be installed and `hashformers-mcp`\n",
+      "   configured, then stop.\n",
+      "2. Determine the language before Transformer segmentation. When the user did\n",
+      "   not supply it:\n",
+      "   - For inline inputs, inspect only a small sample already present in context;\n",
+      "     never call a remote service with the hashtags.\n",
+      "   - For a file, call `sample_hashtag_file` and use only its at-most-20 distinct\n",
+      "     samples. Never open the whole file or copy it into tool arguments.\n",
+      "   - State the inferred dominant language and confidence. If the sample is\n",
+      "     ambiguous or mixed, ask the user. Prefer a multilingual model without\n",
+      "     asking only when it is a clearly safe fallback for the request.\n",
+      "3. If the server reports that model selection is deferred and unconfigured,\n",
+      "   follow the one-time model-selection workflow below before segmentation. For\n",
+      "   inline inputs, configuration state may not be known in advance: if the first\n",
+      "   `segment_hashtags` call reports the specific deferred-selection error, treat\n",
+      "   that as a status signal, complete model selection, and retry the call once.\n",
+      "4. Choose one workflow:\n",
+      "   - Use `start_hashtag_file_job`, then `continue_hashtag_file_job`, when the\n",
+      "     user identifies a local input file.\n",
+      "   - Use `rank_candidates` for hypotheses and scores already supplied by the\n",
+      "     user or another tool.\n",
+      "   - Otherwise use `segment_hashtags`.\n",
+      "5. Preserve input spelling, order, and duplicates. Put up to 64 interactive\n",
+      "   hashtags in one call instead of calling once per hashtag. Split larger\n",
+      "   inline requests into ordered batches; use file jobs when the input is a file.\n",
+      "6. Include nondefault options only when the user requests them or they are\n",
+      "   necessary for the task.\n",
+      "7. Report selected segmentations. Include candidates or component rankings only\n",
+      "   when requested.\n",
+      "\n",
+      "Hashformers does not extract or replace hashtags in complete posts. For a\n",
+      "whole-text workflow, extract hashtags outside the library, pass only those\n",
+      "hashtags to the Transformer workflow, and perform replacement in application\n",
+      "code. Use Python's `re` module or a dedicated heuristic splitter when the user\n",
+      "specifically needs generic regex substitution.\n",
+      "\n",
+      "## Deferred Model Selection\n",
+      "\n",
+      "Use this workflow only when `deferred_model_selection` is true and\n",
+      "`models_configured` is false in a sampling or discovery response, or when an\n",
+      "inline segmentation call returns the server's specific deferred-selection\n",
+      "error. That state means the operator started the server with\n",
+      "`--defer-model-selection`, which is authorization for one validated public Hub\n",
+      "selection and its later download. Proceed directly without asking for a second\n",
+      "download confirmation.\n",
+      "\n",
+      "1. Call `discover_huggingface_models` with the inferred language tag (for\n",
+      "   example `en` or `pt`), `role=\"segmenter\"`, and the default bounded limit.\n",
+      "2. Choose a candidate based on language and architecture compatibility. Treat\n",
+      "   tags, likes, and downloads only as shortlist signals, never as proof of the\n",
+      "   universally best segmenter.\n",
+      "3. Discover a reranker only when the user needs reranker or ensemble selection.\n",
+      "   The official Hugging Face MCP may be used for broader exploration when it is\n",
+      "   already available, but never make it a prerequisite. In either case, pass\n",
+      "   the selected repository and exact revision to Hashformers so it can re-fetch\n",
+      "   and validate the model itself.\n",
+      "4. Call `configure_models` with the segmenter repository ID, exact revision,\n",
+      "   and returned scorer type, plus the same three fields for an optional\n",
+      "   reranker. Do not substitute a branch name such as `main` for the revision.\n",
+      "5. Before the first segmentation or file-job continuation, report the selected\n",
+      "   repository IDs and exact revisions. That next inference may perform the\n",
+      "   potentially large pinned download.\n",
+      "\n",
+      "An identical `configure_models` retry is idempotent. If another selection is\n",
+      "already configured, explain that changing it requires an MCP server restart;\n",
+      "never attempt to hot-swap or retain multiple models. Failed discovery or\n",
+      "validation is not permission to use an unvalidated repository.\n",
+      "\n",
+      "## Large Files\n",
+      "\n",
+      "Pass file paths to `start_hashtag_file_job`; never read the whole file and copy\n",
+      "its hashtags into a tool argument. The server indexes text, CSV, or JSON Lines,\n",
+      "deduplicates normalized hashtags, and creates a persistent local checkpoint.\n",
+      "\n",
+      "When language is unknown, call `sample_hashtag_file` first with the same\n",
+      "`input_format` and `input_field` that the job will use. Its default and maximum\n",
+      "sample size is 20. It streams the file with bounded memory and returns only a\n",
+      "distinct reservoir plus compact counts and format metadata. Never pass the\n",
+      "sample or any other file content to Hugging Face discovery.\n",
+      "\n",
+      "Pass the returned `job_path` to `continue_hashtag_file_job`. Keep calling it\n",
+      "until `status` is `completed`; each call processes a bounded number of unique\n",
+      "hashtags and can be retried after a timeout or client restart. If the user asks\n",
+      "to stop, make no further continuation calls. No work runs in the background.\n",
+      "\n",
+      "Use `input_field` when a CSV column or JSON object field is not named `hashtag`.\n",
+      "Let the server derive an output path unless the user specifies one. Set\n",
+      "`overwrite=true` only when the user explicitly authorizes replacing the target\n",
+      "and the server was started with `--allow-file-overwrite`. File paths must be\n",
+      "inside a directory authorized by the server's `--file-root` startup option.\n",
+      "\n",
+      "After the call, report the output path and summary counts. Do not open or print\n",
+      "the complete output file unless the user explicitly asks; doing so would place\n",
+      "the dataset back into agent context. If verification is requested, inspect only\n",
+      "the requested rows or a small sample.\n",
+      "\n",
+      "## Transformer Options\n",
+      "\n",
+      "For `segment_hashtags` and file jobs:\n",
+      "\n",
+      "- `top_k` is the beam-search width and can change the selected segmentation.\n",
+      "- `steps` is the beam-search depth. MCP calls cap `top_k` at 64 and `steps` at\n",
+      "  32 to keep requests bounded. The server can also reject a batch whose combined\n",
+      "  input lengths, beam width, and depth exceed its aggregate work budget; retry a\n",
+      "  smaller batch or reduce `top_k` or `steps`.\n",
+      "- `max_candidates` only limits serialized alternatives; it does not narrow the\n",
+      "  search. It must be between 1 and 64.\n",
+      "- `ranking_strategy` can be `auto`, `segmenter`, `reranker`, or `ensemble`.\n",
+      "  Reranker and ensemble strategies require a reranker configured for the MCP\n",
+      "  process, either at startup or through authorized deferred selection.\n",
+      "- `alpha` and `beta` configure ensemble selection.\n",
+      "- `lower`, `remove_hashtag`, and `hashtag_character` configure preprocessing.\n",
+      "- `include_component_rankings=true` returns segmenter, reranker, and ensemble\n",
+      "  rankings that actually ran.\n",
+      "\n",
+      "Model names, scorer types, devices, and model batch sizes are normally\n",
+      "server-startup settings. The only exception is one exact-revision selection\n",
+      "authorized by `--defer-model-selection`. If an ordinarily configured model is\n",
+      "unsuitable, tell the user which `hashformers-mcp` startup option must change\n",
+      "rather than calling `configure_models` or silently choosing another model.\n",
+      "\n",
+      "## Tool Contracts\n",
+      "\n",
+      "Call `segment_hashtags` with a `hashtags` list and optional Transformer options.\n",
+      "Expect a `results` list preserving input order. Each item contains the original\n",
+      "and normalized input, selected segmentation, selected ranking strategy, ordered\n",
+      "lower-is-better candidates, and optional component rankings. The response also\n",
+      "records the selected repository IDs and revisions; an exact revision is always\n",
+      "present for deferred/pinned selection and may be null for ordinary unpinned\n",
+      "startup configuration.\n",
+      "\n",
+      "Call `sample_hashtag_file` with `input_path` and optional `input_format`,\n",
+      "`input_field`, and `sample_size`. Expect no more than 20 distinct samples and\n",
+      "compact local metadata, never the full dataset.\n",
+      "\n",
+      "Call `discover_huggingface_models` with a language tag and `segmenter` or\n",
+      "`reranker` role. It returns at most the requested hard-capped number of public,\n",
+      "non-gated, size-bounded candidates with scorer type, architecture, language\n",
+      "tags, size metadata, exact revision, and match reason.\n",
+      "\n",
+      "Call `configure_models` only in authorized deferred mode. Supply exact revision\n",
+      "SHAs for the selected segmenter and optional reranker. Configuration validates\n",
+      "metadata without loading a model; loading remains lazy until inference.\n",
+      "\n",
+      "Call `start_hashtag_file_job` with `input_path` and optional `output_path`,\n",
+      "`input_format`, `input_field`, `overwrite`, and Transformer options. It indexes\n",
+      "the file without model inference and returns a persistent `job_path`.\n",
+      "\n",
+      "Call `continue_hashtag_file_job` with that path and optional\n",
+      "`max_unique_hashtags`. Expect only paths, checkpoint counts, and active model\n",
+      "metadata. Repeat while status is `in_progress`; deferred/pinned selections\n",
+      "always contain an exact revision, while ordinary unpinned startup may report\n",
+      "null. Segmentation records appear in the final output file only when the job\n",
+      "completes. The maximum value is 64; call the tool repeatedly instead of\n",
+      "requesting a larger chunk.\n",
+      "\n",
+      "Call `rank_candidates` with candidate sets shaped as:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"candidate_sets\": [\n",
+      "    {\n",
+      "      \"input\": \"#icecold\",\n",
+      "      \"candidates\": [\n",
+      "        {\"segmentation\": \"ice cold\", \"score\": 1.2},\n",
+      "        {\"segmentation\": \"i ce cold\", \"score\": 2.3}\n",
+      "      ]\n",
+      "    }\n",
+      "  ],\n",
+      "  \"ranking_strategy\": \"segmenter\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Use `segmenter` to select from supplied scores without loading a model. Use\n",
+      "`reranker` or `ensemble` only when the server has a configured reranker.\n",
+      "\n",
+      "## Examples\n",
+      "\n",
+      "For “Segment `#blacklivesmatter`,” call:\n",
+      "\n",
+      "```json\n",
+      "{\"hashtags\": [\"#blacklivesmatter\"]}\n",
+      "```\n",
+      "\n",
+      "For “Show the top three returned candidates using a beam width of 20,” call:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"hashtags\": [\"#therapist\"],\n",
+      "  \"top_k\": 20,\n",
+      "  \"max_candidates\": 3\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "For “Segment every hashtag in `data/hashtags.csv` without loading it into the\n",
+      "chat,” call `start_hashtag_file_job`:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"input_path\": \"data/hashtags.csv\",\n",
+      "  \"input_field\": \"hashtag\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Then call `continue_hashtag_file_job` with the returned checkpoint until it\n",
+      "completes:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"job_path\": \"/absolute/path/hashtags.jsonl.job.sqlite3\",\n",
+      "  \"max_unique_hashtags\": 64\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "The two inputs are plainly English with high confidence. I’ll request three serialized candidates per hashtag from the configured Hashformers segmenter.\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/segment_hashtags\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/segment_hashtags\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "The model inference is running now; it may take a moment if the configured model is loading for the first time.\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "Hashformers returned these ranked candidates (lower score is better):\n",
+      "\n",
+      "- `#weneedanationalpark`\n",
+      "  1. `we need a national park` — 35.0881\n",
+      "  2. `we needa national park` — 41.5704\n",
+      "  3. `we need a nationalpark` — 42.6733\n",
+      "\n",
+      "- `#icecold`\n",
+      "  1. `ice cold` — 27.6499\n",
+      "  2. `icecold` — 28.0752\n",
+      "  3. `icec old` — 36.7408\n",
+      "\n",
+      "These were produced by the configured Hashformers `distilgpt2` segmenter, not estimated manually.\n",
+      "\u001b[2mtokens used\u001b[0m\n",
+      "12,278\n"
+     ]
+    }
+   ],
+   "source": [
+    "CODEX_PROMPT = (\n",
+    "    \"Use the segment-hashtags skill and the Hashformers MCP server to segment \"\n",
+    "    \"#weneedanationalpark and #icecold. Return up to three candidates for each \"\n",
+    "    \"hashtag. Do not estimate the segmentations yourself.\"\n",
+    ")\n",
+    "!codex --ask-for-approval never exec --ephemeral --sandbox read-only \"{CODEX_PROMPT}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "-TqF0WSZZpG8",
+    "outputId": "b1022198-5e1f-4936-c9a1-8b3afaec2158"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Segmented via the Hashformers MCP server (segmenter model: `distilgpt2`, lower score = better):\n",
+      "\n",
+      "**#weneedanationalpark**\n",
+      "1. **we need a national park** (score 35.09)\n",
+      "2. we needa national park (score 41.57)\n",
+      "3. we need a nationalpark (score 42.67)\n",
+      "\n",
+      "**#icecold**\n",
+      "1. **ice cold** (score 27.65)\n",
+      "2. icecold (score 28.08)\n",
+      "3. icec old (score 36.74)\n",
+      "\n",
+      "Top-ranked candidate is bolded for each.\n",
+      "\u001b[?1006l\u001b[?1003l\u001b[?1002l\u001b[?1000l\u001b(B\u000f\u001b[>4m\u001b[<u\u001b[?1004l\u001b[?2031l\u001b[?2004l\u001b[?25h\u001b7\u001b[r\u001b8\u001b]0;\u0007\u001b[?25h"
+     ]
+    }
+   ],
+   "source": [
+    "CLAUDE_PROMPT = (\n",
+    "    \"Use the segment-hashtags skill and the Hashformers MCP server to segment \"\n",
+    "    \"#weneedanationalpark and #icecold. Return up to three candidates for each \"\n",
+    "    \"hashtag. Do not estimate the segmentations yourself.\"\n",
+    ")\n",
+    "!claude -p --allowedTools \"mcp__hashformers__segment_hashtags\" --max-turns 8 \"{CLAUDE_PROMPT}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5FVarGEeZpG9"
+   },
+   "source": [
+    "## 8. Process a CSV with the resumable file workflow\n",
+    "\n",
+    "The agent passes paths—not the whole dataset—to `start_hashtag_file_job`, then calls `continue_hashtag_file_job` until the checkpoint reports completion. The MCP server preserves source order and duplicates in the JSON Lines output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "l9dqh5jCZpG9",
+    "outputId": "a0f93a90-c15c-425b-e622-49d182af5846"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "hashtag\n",
+      "#blacklivesmatter\n",
+      "#myoldphonesucks\n",
+      "#icecold\n",
+      "#icecold\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "CSV_PATH = DATA_DIRECTORY / \"hashtags.csv\"\n",
+    "OUTPUT_PATH = DATA_DIRECTORY / \"segmented.jsonl\"\n",
+    "CSV_PATH.write_text(\n",
+    "    \"hashtag\\n#blacklivesmatter\\n#myoldphonesucks\\n#icecold\\n#icecold\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "print(CSV_PATH.read_text(encoding=\"utf-8\"))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4-EYTnbxZpG-",
+    "outputId": "2ed126c6-fce2-46ca-84f9-a28624bba9f5"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "OpenAI Codex v0.146.0\n",
+      "--------\n",
+      "\u001b[1mworkdir:\u001b[0m /content/hashformers\n",
+      "\u001b[1mmodel:\u001b[0m gpt-5.6-sol\n",
+      "\u001b[1mprovider:\u001b[0m openai\n",
+      "\u001b[1mapproval:\u001b[0m never\n",
+      "\u001b[1msandbox:\u001b[0m workspace-write [workdir, /tmp, $TMPDIR]\n",
+      "\u001b[1mreasoning effort:\u001b[0m none\n",
+      "\u001b[1mreasoning summaries:\u001b[0m none\n",
+      "\u001b[1msession id:\u001b[0m 019fcc7b-2a7e-7762-bd3f-cca3d5fcbf5c\n",
+      "--------\n",
+      "\u001b[36muser\u001b[0m\n",
+      "Use the segment-hashtags skill and Hashformers to segment the hashtags in /content/hashformers/tutorial_data/hashtags.csv. Save the results to /content/hashformers/tutorial_data/segmented.jsonl and continue until the job is complete. Do not open or copy the complete input file into your context.\n",
+      "\u001b[1m\u001b[33mwarning:\u001b[0m\u001b[0m Codex could not find bubblewrap on PATH. Install bubblewrap with your OS package manager. See the sandbox prerequisites: https://developers.openai.com/codex/concepts/sandboxing#prerequisites. Codex will use the bundled bubblewrap in the meantime.\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "I’m using the `segment-hashtags` skill because it provides the streaming workflow for bulk segmentation without loading the full CSV into context. I’ll read its instructions, then run the job through completion and verify the output.\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc \"sed -n '1,240p' .agents/skills/segment-hashtags/SKILL.md\"\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "---\n",
+      "name: segment-hashtags\n",
+      "description: Segment hashtags, sample and process hashtag files without copying their contents into agent context, discover and configure language-appropriate public Hub models, and rank precomputed segmentation candidates with the Hashformers MCP server. Use when a user asks to split or decompound hashtags, run bulk local segmentation, select a model for an unknown language, compare candidates, rerank hypotheses, or inspect component scores.\n",
+      "---\n",
+      "\n",
+      "# Segment with Hashformers\n",
+      "\n",
+      "Use the configured Hashformers MCP server. Never reproduce the algorithm, load a\n",
+      "model directly, or guess segmentations when the tools are unavailable.\n",
+      "\n",
+      "## Workflow\n",
+      "\n",
+      "1. Confirm that the required Hashformers MCP tool is available. If it is not,\n",
+      "   explain that `hashformers[mcp]` must be installed and `hashformers-mcp`\n",
+      "   configured, then stop.\n",
+      "2. Determine the language before Transformer segmentation. When the user did\n",
+      "   not supply it:\n",
+      "   - For inline inputs, inspect only a small sample already present in context;\n",
+      "     never call a remote service with the hashtags.\n",
+      "   - For a file, call `sample_hashtag_file` and use only its at-most-20 distinct\n",
+      "     samples. Never open the whole file or copy it into tool arguments.\n",
+      "   - State the inferred dominant language and confidence. If the sample is\n",
+      "     ambiguous or mixed, ask the user. Prefer a multilingual model without\n",
+      "     asking only when it is a clearly safe fallback for the request.\n",
+      "3. If the server reports that model selection is deferred and unconfigured,\n",
+      "   follow the one-time model-selection workflow below before segmentation. For\n",
+      "   inline inputs, configuration state may not be known in advance: if the first\n",
+      "   `segment_hashtags` call reports the specific deferred-selection error, treat\n",
+      "   that as a status signal, complete model selection, and retry the call once.\n",
+      "4. Choose one workflow:\n",
+      "   - Use `start_hashtag_file_job`, then `continue_hashtag_file_job`, when the\n",
+      "     user identifies a local input file.\n",
+      "   - Use `rank_candidates` for hypotheses and scores already supplied by the\n",
+      "     user or another tool.\n",
+      "   - Otherwise use `segment_hashtags`.\n",
+      "5. Preserve input spelling, order, and duplicates. Put up to 64 interactive\n",
+      "   hashtags in one call instead of calling once per hashtag. Split larger\n",
+      "   inline requests into ordered batches; use file jobs when the input is a file.\n",
+      "6. Include nondefault options only when the user requests them or they are\n",
+      "   necessary for the task.\n",
+      "7. Report selected segmentations. Include candidates or component rankings only\n",
+      "   when requested.\n",
+      "\n",
+      "Hashformers does not extract or replace hashtags in complete posts. For a\n",
+      "whole-text workflow, extract hashtags outside the library, pass only those\n",
+      "hashtags to the Transformer workflow, and perform replacement in application\n",
+      "code. Use Python's `re` module or a dedicated heuristic splitter when the user\n",
+      "specifically needs generic regex substitution.\n",
+      "\n",
+      "## Deferred Model Selection\n",
+      "\n",
+      "Use this workflow only when `deferred_model_selection` is true and\n",
+      "`models_configured` is false in a sampling or discovery response, or when an\n",
+      "inline segmentation call returns the server's specific deferred-selection\n",
+      "error. That state means the operator started the server with\n",
+      "`--defer-model-selection`, which is authorization for one validated public Hub\n",
+      "selection and its later download. Proceed directly without asking for a second\n",
+      "download confirmation.\n",
+      "\n",
+      "1. Call `discover_huggingface_models` with the inferred language tag (for\n",
+      "   example `en` or `pt`), `role=\"segmenter\"`, and the default bounded limit.\n",
+      "2. Choose a candidate based on language and architecture compatibility. Treat\n",
+      "   tags, likes, and downloads only as shortlist signals, never as proof of the\n",
+      "   universally best segmenter.\n",
+      "3. Discover a reranker only when the user needs reranker or ensemble selection.\n",
+      "   The official Hugging Face MCP may be used for broader exploration when it is\n",
+      "   already available, but never make it a prerequisite. In either case, pass\n",
+      "   the selected repository and exact revision to Hashformers so it can re-fetch\n",
+      "   and validate the model itself.\n",
+      "4. Call `configure_models` with the segmenter repository ID, exact revision,\n",
+      "   and returned scorer type, plus the same three fields for an optional\n",
+      "   reranker. Do not substitute a branch name such as `main` for the revision.\n",
+      "5. Before the first segmentation or file-job continuation, report the selected\n",
+      "   repository IDs and exact revisions. That next inference may perform the\n",
+      "   potentially large pinned download.\n",
+      "\n",
+      "An identical `configure_models` retry is idempotent. If another selection is\n",
+      "already configured, explain that changing it requires an MCP server restart;\n",
+      "never attempt to hot-swap or retain multiple models. Failed discovery or\n",
+      "validation is not permission to use an unvalidated repository.\n",
+      "\n",
+      "## Large Files\n",
+      "\n",
+      "Pass file paths to `start_hashtag_file_job`; never read the whole file and copy\n",
+      "its hashtags into a tool argument. The server indexes text, CSV, or JSON Lines,\n",
+      "deduplicates normalized hashtags, and creates a persistent local checkpoint.\n",
+      "\n",
+      "When language is unknown, call `sample_hashtag_file` first with the same\n",
+      "`input_format` and `input_field` that the job will use. Its default and maximum\n",
+      "sample size is 20. It streams the file with bounded memory and returns only a\n",
+      "distinct reservoir plus compact counts and format metadata. Never pass the\n",
+      "sample or any other file content to Hugging Face discovery.\n",
+      "\n",
+      "Pass the returned `job_path` to `continue_hashtag_file_job`. Keep calling it\n",
+      "until `status` is `completed`; each call processes a bounded number of unique\n",
+      "hashtags and can be retried after a timeout or client restart. If the user asks\n",
+      "to stop, make no further continuation calls. No work runs in the background.\n",
+      "\n",
+      "Use `input_field` when a CSV column or JSON object field is not named `hashtag`.\n",
+      "Let the server derive an output path unless the user specifies one. Set\n",
+      "`overwrite=true` only when the user explicitly authorizes replacing the target\n",
+      "and the server was started with `--allow-file-overwrite`. File paths must be\n",
+      "inside a directory authorized by the server's `--file-root` startup option.\n",
+      "\n",
+      "After the call, report the output path and summary counts. Do not open or print\n",
+      "the complete output file unless the user explicitly asks; doing so would place\n",
+      "the dataset back into agent context. If verification is requested, inspect only\n",
+      "the requested rows or a small sample.\n",
+      "\n",
+      "## Transformer Options\n",
+      "\n",
+      "For `segment_hashtags` and file jobs:\n",
+      "\n",
+      "- `top_k` is the beam-search width and can change the selected segmentation.\n",
+      "- `steps` is the beam-search depth. MCP calls cap `top_k` at 64 and `steps` at\n",
+      "  32 to keep requests bounded. The server can also reject a batch whose combined\n",
+      "  input lengths, beam width, and depth exceed its aggregate work budget; retry a\n",
+      "  smaller batch or reduce `top_k` or `steps`.\n",
+      "- `max_candidates` only limits serialized alternatives; it does not narrow the\n",
+      "  search. It must be between 1 and 64.\n",
+      "- `ranking_strategy` can be `auto`, `segmenter`, `reranker`, or `ensemble`.\n",
+      "  Reranker and ensemble strategies require a reranker configured for the MCP\n",
+      "  process, either at startup or through authorized deferred selection.\n",
+      "- `alpha` and `beta` configure ensemble selection.\n",
+      "- `lower`, `remove_hashtag`, and `hashtag_character` configure preprocessing.\n",
+      "- `include_component_rankings=true` returns segmenter, reranker, and ensemble\n",
+      "  rankings that actually ran.\n",
+      "\n",
+      "Model names, scorer types, devices, and model batch sizes are normally\n",
+      "server-startup settings. The only exception is one exact-revision selection\n",
+      "authorized by `--defer-model-selection`. If an ordinarily configured model is\n",
+      "unsuitable, tell the user which `hashformers-mcp` startup option must change\n",
+      "rather than calling `configure_models` or silently choosing another model.\n",
+      "\n",
+      "## Tool Contracts\n",
+      "\n",
+      "Call `segment_hashtags` with a `hashtags` list and optional Transformer options.\n",
+      "Expect a `results` list preserving input order. Each item contains the original\n",
+      "and normalized input, selected segmentation, selected ranking strategy, ordered\n",
+      "lower-is-better candidates, and optional component rankings. The response also\n",
+      "records the selected repository IDs and revisions; an exact revision is always\n",
+      "present for deferred/pinned selection and may be null for ordinary unpinned\n",
+      "startup configuration.\n",
+      "\n",
+      "Call `sample_hashtag_file` with `input_path` and optional `input_format`,\n",
+      "`input_field`, and `sample_size`. Expect no more than 20 distinct samples and\n",
+      "compact local metadata, never the full dataset.\n",
+      "\n",
+      "Call `discover_huggingface_models` with a language tag and `segmenter` or\n",
+      "`reranker` role. It returns at most the requested hard-capped number of public,\n",
+      "non-gated, size-bounded candidates with scorer type, architecture, language\n",
+      "tags, size metadata, exact revision, and match reason.\n",
+      "\n",
+      "Call `configure_models` only in authorized deferred mode. Supply exact revision\n",
+      "SHAs for the selected segmenter and optional reranker. Configuration validates\n",
+      "metadata without loading a model; loading remains lazy until inference.\n",
+      "\n",
+      "Call `start_hashtag_file_job` with `input_path` and optional `output_path`,\n",
+      "`input_format`, `input_field`, `overwrite`, and Transformer options. It indexes\n",
+      "the file without model inference and returns a persistent `job_path`.\n",
+      "\n",
+      "Call `continue_hashtag_file_job` with that path and optional\n",
+      "`max_unique_hashtags`. Expect only paths, checkpoint counts, and active model\n",
+      "metadata. Repeat while status is `in_progress`; deferred/pinned selections\n",
+      "always contain an exact revision, while ordinary unpinned startup may report\n",
+      "null. Segmentation records appear in the final output file only when the job\n",
+      "completes. The maximum value is 64; call the tool repeatedly instead of\n",
+      "requesting a larger chunk.\n",
+      "\n",
+      "Call `rank_candidates` with candidate sets shaped as:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"candidate_sets\": [\n",
+      "    {\n",
+      "      \"input\": \"#icecold\",\n",
+      "      \"candidates\": [\n",
+      "        {\"segmentation\": \"ice cold\", \"score\": 1.2},\n",
+      "        {\"segmentation\": \"i ce cold\", \"score\": 2.3}\n",
+      "      ]\n",
+      "    }\n",
+      "  ],\n",
+      "  \"ranking_strategy\": \"segmenter\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Use `segmenter` to select from supplied scores without loading a model. Use\n",
+      "`reranker` or `ensemble` only when the server has a configured reranker.\n",
+      "\n",
+      "## Examples\n",
+      "\n",
+      "For “Segment `#blacklivesmatter`,” call:\n",
+      "\n",
+      "```json\n",
+      "{\"hashtags\": [\"#blacklivesmatter\"]}\n",
+      "```\n",
+      "\n",
+      "For “Show the top three returned candidates using a beam width of 20,” call:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"hashtags\": [\"#therapist\"],\n",
+      "  \"top_k\": 20,\n",
+      "  \"max_candidates\": 3\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "For “Segment every hashtag in `data/hashtags.csv` without loading it into the\n",
+      "chat,” call `start_hashtag_file_job`:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"input_path\": \"data/hashtags.csv\",\n",
+      "  \"input_field\": \"hashtag\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Then call `continue_hashtag_file_job` with the returned checkpoint until it\n",
+      "completes:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"job_path\": \"/absolute/path/hashtags.jsonl.job.sqlite3\",\n",
+      "  \"max_unique_hashtags\": 64\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/sample_hashtag_file\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/sample_hashtag_file\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "The bounded sample contains 3 distinct examples across 4 rows; the dominant language is English with high confidence. Hashformers already has its models configured, so I’m starting the resumable CSV job with the requested output path.\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc 'if test -e tutorial_data/segmented.jsonl; then echo exists; else echo absent; fi'\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "absent\n",
+      "\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/start_hashtag_file_job\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/start_hashtag_file_job\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/continue_hashtag_file_job\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/continue_hashtag_file_job\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc \"stat -c 'path=%n size_bytes=%s' tutorial_data/segmented.jsonl && wc -l < tutorial_data/segmented.jsonl\"\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "path=tutorial_data/segmented.jsonl size_bytes=1657\n",
+      "4\n",
+      "\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "Segmentation completed successfully.\n",
+      "\n",
+      "- Output: [segmented.jsonl](/content/hashformers/tutorial_data/segmented.jsonl)\n",
+      "- Input rows: 4\n",
+      "- Unique hashtags processed: 3\n",
+      "- Duplicate rows preserved: 1\n",
+      "- Output rows: 4\n",
+      "- Model: `distilgpt2`\n",
+      "\u001b[2mtokens used\u001b[0m\n",
+      "24,774\n"
+     ]
+    }
+   ],
+   "source": [
+    "FILE_PROMPT = (\n",
+    "    f\"Use the segment-hashtags skill and Hashformers to segment the hashtags in {CSV_PATH}. \"\n",
+    "    f\"Save the results to {OUTPUT_PATH} and continue until the job is complete. \"\n",
+    "    \"Do not open or copy the complete input file into your context.\"\n",
+    ")\n",
+    "!codex -c 'mcp_servers.hashformers.tools.start_hashtag_file_job.approval_mode=\"approve\"' -c 'mcp_servers.hashformers.tools.continue_hashtag_file_job.approval_mode=\"approve\"' --ask-for-approval never exec --ephemeral --sandbox workspace-write \"{FILE_PROMPT}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "-OUNoqJPZpG_",
+    "outputId": "35b0f8c0-57cf-4186-8a3b-9defc8732704"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Output records: 4\n",
+      "#blacklivesmatter -> blacklivesmatter\n",
+      "#myoldphonesucks -> my old phone sucks\n",
+      "#icecold -> ice cold\n",
+      "#icecold -> ice cold\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "records = [json.loads(line) for line in OUTPUT_PATH.read_text().splitlines()]\n",
+    "print(f\"Output records: {len(records)}\")\n",
+    "for record in records:\n",
+    "    print(record[\"input\"], \"->\", record[\"selected_segmentation\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FZcu-fOTZpHA"
+   },
+   "source": [
+    "## 9. Configure deferred model selection for an unknown language\n",
+    "\n",
+    "A server started with `--defer-model-selection` loads no Transformer at startup. The skill can sample at most 20 distinct local examples, infer a language, ask Hashformers for a bounded public Hugging Face shortlist, and configure one exact model revision before inference. A running server cannot hot-swap models, so this example replaces Codex's earlier registration and starts a fresh agent session.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DJJcF8x3ZpHA",
+    "outputId": "3ca66dd8-3012-480b-bc5a-8636934bd6a4"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Removed global MCP server 'hashformers'.\n",
+      "Added global MCP server 'hashformers'.\n",
+      "hashformers\n",
+      "  enabled: true\n",
+      "  transport: stdio\n",
+      "  command: hashformers-mcp\n",
+      "  args: --defer-model-selection --file-root /content/hashformers/tutorial_data\n",
+      "  cwd: -\n",
+      "  env: -\n",
+      "  remove: codex mcp remove hashformers\n"
+     ]
+    }
+   ],
+   "source": [
+    "UNKNOWN_LANGUAGE_PATH = DATA_DIRECTORY / \"unknown_language.csv\"\n",
+    "UNKNOWN_OUTPUT_PATH = DATA_DIRECTORY / \"unknown_language_segmented.jsonl\"\n",
+    "UNKNOWN_LANGUAGE_PATH.write_text(\n",
+    "    \"hashtag\\n#saopaulomeuamor\\n#futebolbrasileiro\\n#cafecomleite\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "\n",
+    "!codex mcp remove hashformers\n",
+    "!codex mcp add hashformers -- hashformers-mcp --defer-model-selection --file-root {DATA_DIRECTORY}\n",
+    "!codex mcp get hashformers\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "odk3iu8PZpHB",
+    "outputId": "65fa8c7a-299e-4a10-9207-b01fcf1c25e0"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "OpenAI Codex v0.146.0\n",
+      "--------\n",
+      "\u001b[1mworkdir:\u001b[0m /content/hashformers\n",
+      "\u001b[1mmodel:\u001b[0m gpt-5.6-sol\n",
+      "\u001b[1mprovider:\u001b[0m openai\n",
+      "\u001b[1mapproval:\u001b[0m never\n",
+      "\u001b[1msandbox:\u001b[0m workspace-write [workdir, /tmp, $TMPDIR]\n",
+      "\u001b[1mreasoning effort:\u001b[0m none\n",
+      "\u001b[1mreasoning summaries:\u001b[0m none\n",
+      "\u001b[1msession id:\u001b[0m 019fcc7d-742a-7531-8f04-e9cbcf1bbe6a\n",
+      "--------\n",
+      "\u001b[36muser\u001b[0m\n",
+      "Use the segment-hashtags skill and Hashformers to sample /content/hashformers/tutorial_data/unknown_language.csv, identify its language, select a compatible public Hugging Face segmenter at an exact revision, and segment the file to /content/hashformers/tutorial_data/unknown_language_segmented.jsonl. Continue until the job is complete.\n",
+      "\u001b[1m\u001b[33mwarning:\u001b[0m\u001b[0m Codex could not find bubblewrap on PATH. Install bubblewrap with your OS package manager. See the sandbox prerequisites: https://developers.openai.com/codex/concepts/sandboxing#prerequisites. Codex will use the bundled bubblewrap in the meantime.\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "I’m using the `segment-hashtags` skill because this is its full unknown-language workflow: sample safely, identify the language, pin a compatible public model revision, and process the file. I’ll follow it through to a verified JSONL output.\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc \"sed -n '1,240p' .agents/skills/segment-hashtags/SKILL.md\"\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "---\n",
+      "name: segment-hashtags\n",
+      "description: Segment hashtags, sample and process hashtag files without copying their contents into agent context, discover and configure language-appropriate public Hub models, and rank precomputed segmentation candidates with the Hashformers MCP server. Use when a user asks to split or decompound hashtags, run bulk local segmentation, select a model for an unknown language, compare candidates, rerank hypotheses, or inspect component scores.\n",
+      "---\n",
+      "\n",
+      "# Segment with Hashformers\n",
+      "\n",
+      "Use the configured Hashformers MCP server. Never reproduce the algorithm, load a\n",
+      "model directly, or guess segmentations when the tools are unavailable.\n",
+      "\n",
+      "## Workflow\n",
+      "\n",
+      "1. Confirm that the required Hashformers MCP tool is available. If it is not,\n",
+      "   explain that `hashformers[mcp]` must be installed and `hashformers-mcp`\n",
+      "   configured, then stop.\n",
+      "2. Determine the language before Transformer segmentation. When the user did\n",
+      "   not supply it:\n",
+      "   - For inline inputs, inspect only a small sample already present in context;\n",
+      "     never call a remote service with the hashtags.\n",
+      "   - For a file, call `sample_hashtag_file` and use only its at-most-20 distinct\n",
+      "     samples. Never open the whole file or copy it into tool arguments.\n",
+      "   - State the inferred dominant language and confidence. If the sample is\n",
+      "     ambiguous or mixed, ask the user. Prefer a multilingual model without\n",
+      "     asking only when it is a clearly safe fallback for the request.\n",
+      "3. If the server reports that model selection is deferred and unconfigured,\n",
+      "   follow the one-time model-selection workflow below before segmentation. For\n",
+      "   inline inputs, configuration state may not be known in advance: if the first\n",
+      "   `segment_hashtags` call reports the specific deferred-selection error, treat\n",
+      "   that as a status signal, complete model selection, and retry the call once.\n",
+      "4. Choose one workflow:\n",
+      "   - Use `start_hashtag_file_job`, then `continue_hashtag_file_job`, when the\n",
+      "     user identifies a local input file.\n",
+      "   - Use `rank_candidates` for hypotheses and scores already supplied by the\n",
+      "     user or another tool.\n",
+      "   - Otherwise use `segment_hashtags`.\n",
+      "5. Preserve input spelling, order, and duplicates. Put up to 64 interactive\n",
+      "   hashtags in one call instead of calling once per hashtag. Split larger\n",
+      "   inline requests into ordered batches; use file jobs when the input is a file.\n",
+      "6. Include nondefault options only when the user requests them or they are\n",
+      "   necessary for the task.\n",
+      "7. Report selected segmentations. Include candidates or component rankings only\n",
+      "   when requested.\n",
+      "\n",
+      "Hashformers does not extract or replace hashtags in complete posts. For a\n",
+      "whole-text workflow, extract hashtags outside the library, pass only those\n",
+      "hashtags to the Transformer workflow, and perform replacement in application\n",
+      "code. Use Python's `re` module or a dedicated heuristic splitter when the user\n",
+      "specifically needs generic regex substitution.\n",
+      "\n",
+      "## Deferred Model Selection\n",
+      "\n",
+      "Use this workflow only when `deferred_model_selection` is true and\n",
+      "`models_configured` is false in a sampling or discovery response, or when an\n",
+      "inline segmentation call returns the server's specific deferred-selection\n",
+      "error. That state means the operator started the server with\n",
+      "`--defer-model-selection`, which is authorization for one validated public Hub\n",
+      "selection and its later download. Proceed directly without asking for a second\n",
+      "download confirmation.\n",
+      "\n",
+      "1. Call `discover_huggingface_models` with the inferred language tag (for\n",
+      "   example `en` or `pt`), `role=\"segmenter\"`, and the default bounded limit.\n",
+      "2. Choose a candidate based on language and architecture compatibility. Treat\n",
+      "   tags, likes, and downloads only as shortlist signals, never as proof of the\n",
+      "   universally best segmenter.\n",
+      "3. Discover a reranker only when the user needs reranker or ensemble selection.\n",
+      "   The official Hugging Face MCP may be used for broader exploration when it is\n",
+      "   already available, but never make it a prerequisite. In either case, pass\n",
+      "   the selected repository and exact revision to Hashformers so it can re-fetch\n",
+      "   and validate the model itself.\n",
+      "4. Call `configure_models` with the segmenter repository ID, exact revision,\n",
+      "   and returned scorer type, plus the same three fields for an optional\n",
+      "   reranker. Do not substitute a branch name such as `main` for the revision.\n",
+      "5. Before the first segmentation or file-job continuation, report the selected\n",
+      "   repository IDs and exact revisions. That next inference may perform the\n",
+      "   potentially large pinned download.\n",
+      "\n",
+      "An identical `configure_models` retry is idempotent. If another selection is\n",
+      "already configured, explain that changing it requires an MCP server restart;\n",
+      "never attempt to hot-swap or retain multiple models. Failed discovery or\n",
+      "validation is not permission to use an unvalidated repository.\n",
+      "\n",
+      "## Large Files\n",
+      "\n",
+      "Pass file paths to `start_hashtag_file_job`; never read the whole file and copy\n",
+      "its hashtags into a tool argument. The server indexes text, CSV, or JSON Lines,\n",
+      "deduplicates normalized hashtags, and creates a persistent local checkpoint.\n",
+      "\n",
+      "When language is unknown, call `sample_hashtag_file` first with the same\n",
+      "`input_format` and `input_field` that the job will use. Its default and maximum\n",
+      "sample size is 20. It streams the file with bounded memory and returns only a\n",
+      "distinct reservoir plus compact counts and format metadata. Never pass the\n",
+      "sample or any other file content to Hugging Face discovery.\n",
+      "\n",
+      "Pass the returned `job_path` to `continue_hashtag_file_job`. Keep calling it\n",
+      "until `status` is `completed`; each call processes a bounded number of unique\n",
+      "hashtags and can be retried after a timeout or client restart. If the user asks\n",
+      "to stop, make no further continuation calls. No work runs in the background.\n",
+      "\n",
+      "Use `input_field` when a CSV column or JSON object field is not named `hashtag`.\n",
+      "Let the server derive an output path unless the user specifies one. Set\n",
+      "`overwrite=true` only when the user explicitly authorizes replacing the target\n",
+      "and the server was started with `--allow-file-overwrite`. File paths must be\n",
+      "inside a directory authorized by the server's `--file-root` startup option.\n",
+      "\n",
+      "After the call, report the output path and summary counts. Do not open or print\n",
+      "the complete output file unless the user explicitly asks; doing so would place\n",
+      "the dataset back into agent context. If verification is requested, inspect only\n",
+      "the requested rows or a small sample.\n",
+      "\n",
+      "## Transformer Options\n",
+      "\n",
+      "For `segment_hashtags` and file jobs:\n",
+      "\n",
+      "- `top_k` is the beam-search width and can change the selected segmentation.\n",
+      "- `steps` is the beam-search depth. MCP calls cap `top_k` at 64 and `steps` at\n",
+      "  32 to keep requests bounded. The server can also reject a batch whose combined\n",
+      "  input lengths, beam width, and depth exceed its aggregate work budget; retry a\n",
+      "  smaller batch or reduce `top_k` or `steps`.\n",
+      "- `max_candidates` only limits serialized alternatives; it does not narrow the\n",
+      "  search. It must be between 1 and 64.\n",
+      "- `ranking_strategy` can be `auto`, `segmenter`, `reranker`, or `ensemble`.\n",
+      "  Reranker and ensemble strategies require a reranker configured for the MCP\n",
+      "  process, either at startup or through authorized deferred selection.\n",
+      "- `alpha` and `beta` configure ensemble selection.\n",
+      "- `lower`, `remove_hashtag`, and `hashtag_character` configure preprocessing.\n",
+      "- `include_component_rankings=true` returns segmenter, reranker, and ensemble\n",
+      "  rankings that actually ran.\n",
+      "\n",
+      "Model names, scorer types, devices, and model batch sizes are normally\n",
+      "server-startup settings. The only exception is one exact-revision selection\n",
+      "authorized by `--defer-model-selection`. If an ordinarily configured model is\n",
+      "unsuitable, tell the user which `hashformers-mcp` startup option must change\n",
+      "rather than calling `configure_models` or silently choosing another model.\n",
+      "\n",
+      "## Tool Contracts\n",
+      "\n",
+      "Call `segment_hashtags` with a `hashtags` list and optional Transformer options.\n",
+      "Expect a `results` list preserving input order. Each item contains the original\n",
+      "and normalized input, selected segmentation, selected ranking strategy, ordered\n",
+      "lower-is-better candidates, and optional component rankings. The response also\n",
+      "records the selected repository IDs and revisions; an exact revision is always\n",
+      "present for deferred/pinned selection and may be null for ordinary unpinned\n",
+      "startup configuration.\n",
+      "\n",
+      "Call `sample_hashtag_file` with `input_path` and optional `input_format`,\n",
+      "`input_field`, and `sample_size`. Expect no more than 20 distinct samples and\n",
+      "compact local metadata, never the full dataset.\n",
+      "\n",
+      "Call `discover_huggingface_models` with a language tag and `segmenter` or\n",
+      "`reranker` role. It returns at most the requested hard-capped number of public,\n",
+      "non-gated, size-bounded candidates with scorer type, architecture, language\n",
+      "tags, size metadata, exact revision, and match reason.\n",
+      "\n",
+      "Call `configure_models` only in authorized deferred mode. Supply exact revision\n",
+      "SHAs for the selected segmenter and optional reranker. Configuration validates\n",
+      "metadata without loading a model; loading remains lazy until inference.\n",
+      "\n",
+      "Call `start_hashtag_file_job` with `input_path` and optional `output_path`,\n",
+      "`input_format`, `input_field`, `overwrite`, and Transformer options. It indexes\n",
+      "the file without model inference and returns a persistent `job_path`.\n",
+      "\n",
+      "Call `continue_hashtag_file_job` with that path and optional\n",
+      "`max_unique_hashtags`. Expect only paths, checkpoint counts, and active model\n",
+      "metadata. Repeat while status is `in_progress`; deferred/pinned selections\n",
+      "always contain an exact revision, while ordinary unpinned startup may report\n",
+      "null. Segmentation records appear in the final output file only when the job\n",
+      "completes. The maximum value is 64; call the tool repeatedly instead of\n",
+      "requesting a larger chunk.\n",
+      "\n",
+      "Call `rank_candidates` with candidate sets shaped as:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"candidate_sets\": [\n",
+      "    {\n",
+      "      \"input\": \"#icecold\",\n",
+      "      \"candidates\": [\n",
+      "        {\"segmentation\": \"ice cold\", \"score\": 1.2},\n",
+      "        {\"segmentation\": \"i ce cold\", \"score\": 2.3}\n",
+      "      ]\n",
+      "    }\n",
+      "  ],\n",
+      "  \"ranking_strategy\": \"segmenter\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Use `segmenter` to select from supplied scores without loading a model. Use\n",
+      "`reranker` or `ensemble` only when the server has a configured reranker.\n",
+      "\n",
+      "## Examples\n",
+      "\n",
+      "For “Segment `#blacklivesmatter`,” call:\n",
+      "\n",
+      "```json\n",
+      "{\"hashtags\": [\"#blacklivesmatter\"]}\n",
+      "```\n",
+      "\n",
+      "For “Show the top three returned candidates using a beam width of 20,” call:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"hashtags\": [\"#therapist\"],\n",
+      "  \"top_k\": 20,\n",
+      "  \"max_candidates\": 3\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "For “Segment every hashtag in `data/hashtags.csv` without loading it into the\n",
+      "chat,” call `start_hashtag_file_job`:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"input_path\": \"data/hashtags.csv\",\n",
+      "  \"input_field\": \"hashtag\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Then call `continue_hashtag_file_job` with the returned checkpoint until it\n",
+      "completes:\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"job_path\": \"/absolute/path/hashtags.jsonl.job.sqlite3\",\n",
+      "  \"max_unique_hashtags\": 64\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/sample_hashtag_file\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/sample_hashtag_file\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "The bounded sample contains three distinct hashtags and is clearly Brazilian Portuguese (São Paulo, futebol brasileiro, café com leite), with high confidence. The server confirms deferred model selection is authorized and no model is configured, so I’m now discovering a public Portuguese segmenter and will pin its exact validated revision.\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/discover_huggingface_models\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/discover_huggingface_models\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/configure_models\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/configure_models\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "Selected and validated `FacebookAI/xlm-roberta-base` with the exact revision `e73636d4f797dec63c3081bb6ed5c7b0bb3f2089` and the compatible `bert` scorer. It explicitly supports Portuguese and is the strongest bounded shortlist signal among compatible candidates. I’m starting the requested file job now; its first inference may download the pinned model.\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/start_hashtag_file_job\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/start_hashtag_file_job\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/continue_hashtag_file_job\u001b[0m \u001b[2mstarted\u001b[0m\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "The job is checkpointed with 3 total/unique hashtags and is currently loading or downloading the pinned model for its inference chunk. I’ll keep continuing the resumable job until the server reports `completed`, then verify the output path and compact counts without dumping the dataset.\n",
+      "\u001b[1mmcp:\u001b[0m \u001b[36mhashformers/continue_hashtag_file_job\u001b[0m \u001b[2m(\u001b[32mcompleted\u001b[0m)\u001b[0m\n",
+      "\u001b[35m\u001b[3mexec\u001b[0m\u001b[0m\n",
+      "\u001b[1m/bin/bash -lc \"wc -l /content/hashformers/tutorial_data/unknown_language_segmented.jsonl && stat -c '%n %s bytes' /content/hashformers/tutorial_data/unknown_language_segmented.jsonl\"\u001b[0m in /content/hashformers\n",
+      "\u001b[32m succeeded in 0ms:\u001b[0m\n",
+      "3 /content/hashformers/tutorial_data/unknown_language_segmented.jsonl\n",
+      "/content/hashformers/tutorial_data/unknown_language_segmented.jsonl 1453 bytes\n",
+      "\n",
+      "\u001b[35m\u001b[3mcodex\u001b[0m\u001b[0m\n",
+      "Segmentation completed successfully.\n",
+      "\n",
+      "- Language: Brazilian Portuguese (`pt`), high confidence\n",
+      "- Model: `FacebookAI/xlm-roberta-base`\n",
+      "- Exact revision: `e73636d4f797dec63c3081bb6ed5c7b0bb3f2089`\n",
+      "- Scorer: `bert`\n",
+      "- Processed: 3 of 3 hashtags\n",
+      "- Output: [unknown_language_segmented.jsonl](/content/hashformers/tutorial_data/unknown_language_segmented.jsonl)\n",
+      "- Verification: 3 JSONL records, 1,453 bytes\n",
+      "\u001b[2mtokens used\u001b[0m\n",
+      "21,521\n"
+     ]
+    }
+   ],
+   "source": [
+    "DEFERRED_PROMPT = (\n",
+    "    f\"Use the segment-hashtags skill and Hashformers to sample {UNKNOWN_LANGUAGE_PATH}, \"\n",
+    "    \"identify its language, select a compatible public Hugging Face segmenter at an exact \"\n",
+    "    f\"revision, and segment the file to {UNKNOWN_OUTPUT_PATH}. Continue until the job is complete.\"\n",
+    ")\n",
+    "!codex -c 'mcp_servers.hashformers.tools.configure_models.approval_mode=\"approve\"' -c 'mcp_servers.hashformers.tools.start_hashtag_file_job.approval_mode=\"approve\"' -c 'mcp_servers.hashformers.tools.continue_hashtag_file_job.approval_mode=\"approve\"' --ask-for-approval never exec --ephemeral --sandbox workspace-write \"{DEFERRED_PROMPT}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "buGpF1lkZpHC"
+   },
+   "source": [
+    "## What to take to a local machine\n",
+    "\n",
+    "Outside Colab, install a released build with `pip install \"hashformers[mcp]\"`, copy the skill to the client-specific personal skill directory, and use the same `codex mcp add` or `claude mcp add` commands. Authorize only the file roots the agent actually needs. Run `hashformers-mcp --help` for model, reranker, device, batch-size, and file-access options.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## What

- add an executed Colab notebook that installs Hashformers from Git, Codex CLI, Claude Code, the Hashformers MCP server, and the `segment-hashtags` skill
- demonstrate the README's interactive segmentation, resumable file-job, and deferred unknown-language model-selection workflows through both agent clients
- link the new tutorial immediately below the basic Colab tutorial and in the README quick links
- preserve all demonstration outputs while clearing the two one-time authentication outputs

## Validation

- ran the complete notebook on a Google Colab T4, including Codex and Claude Code authentication, interactive MCP calls, a resumable four-record file job, and exact-revision deferred selection with `FacebookAI/xlm-roberta-base`
- validated notebook JSON/metadata: 17 code cells, outputs preserved in 15 demo cells, two auth cells sanitized
- `pytest -q tests/test_mcp_model_selection.py`: 21 passed
- broader non-GPU suite: 202 passed, 6 pre-existing baseline failures, 1 deselected; the local GPU-only module intentionally raises during collection without a GPU

The six baseline failures are unrelated stale expectations in MCP fusion responses, published benchmark artifacts, and the newly merged README compatibility assertion.