### PR TITLE
Prevent MCP startup timeouts with lazy runtime imports

### DIFF
--- a/src/hashformers/__init__.py
+++ b/src/hashformers/__init__.py
@@ -1,2 +1,82 @@
-from hashformers.segmenter import *
-from hashformers.segmenter.auto import *
+"""Public Hashformers API with dependency-lazy exports.
+
+Importing the package must stay lightweight so entry points such as the MCP
+server can complete their protocol handshake before the Transformer runtime is
+needed.  Public objects retain their historical top-level import locations and
+are loaded on first attribute access.
+"""
+
+from importlib import import_module
+from typing import Any
+
+
+_LAZY_EXPORTS = {
+    "Any": ("typing", "Any"),
+    "BaseSegmenter": (
+        "hashformers.segmenter.base_segmenter",
+        "BaseSegmenter",
+    ),
+    "BaseWordSegmenter": (
+        "hashformers.segmenter.segmenter",
+        "BaseWordSegmenter",
+    ),
+    "Beamsearch": ("hashformers.beamsearch.algorithm", "Beamsearch"),
+    "DEFAULT_MAX_BATCH_SIZE": (
+        "hashformers.batching",
+        "DEFAULT_MAX_BATCH_SIZE",
+    ),
+    "ReciprocalRankFusionEnsembler": (
+        "hashformers.ensemble.rrf_fusion",
+        "ReciprocalRankFusionEnsembler",
+    ),
+    "Reranker": ("hashformers.beamsearch.reranker", "Reranker"),
+    "Top2_Ensembler": (
+        "hashformers.ensemble.top2_fusion",
+        "Top2_Ensembler",
+    ),
+    "TransformerWordSegmenter": (
+        "hashformers.segmenter.auto",
+        "TransformerWordSegmenter",
+    ),
+    "WordSegmenterOutput": (
+        "hashformers.segmenter.data_structures",
+        "WordSegmenterOutput",
+    ),
+    "enforce_prob_dict": (
+        "hashformers.beamsearch.data_structures",
+        "enforce_prob_dict",
+    ),
+}
+_LAZY_MODULES = {
+    "base_segmenter": "hashformers.segmenter.base_segmenter",
+    "beamsearch": "hashformers.beamsearch",
+    "data_structures": "hashformers.segmenter.data_structures",
+    "ensemble": "hashformers.ensemble",
+    "evaluation": "hashformers.evaluation",
+    "experiments": "hashformers.experiments",
+    "segmenter": "hashformers.segmenter",
+}
+
+__all__ = [*_LAZY_EXPORTS, *_LAZY_MODULES]
+
+
+def __getattr__(name: str) -> Any:
+    """Load one historical top-level export on first use."""
+    if name in _LAZY_MODULES:
+        value = import_module(_LAZY_MODULES[name])
+        globals()[name] = value
+        return value
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError as error:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        ) from error
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include unresolved lazy exports in interactive discovery."""
+    return sorted({*globals(), *__all__})

--- a/src/hashformers/batching.py
+++ b/src/hashformers/batching.py
@@ -1,0 +1,28 @@
+"""Dependency-free validation for Hashformers inference batch sizes."""
+
+from typing import Literal
+
+
+AUTO_BATCH_SIZE = "auto"
+DEFAULT_AUTO_BATCH_SIZE = 64
+DEFAULT_MAX_BATCH_SIZE = 512
+
+
+def validate_batch_size(
+    value: int | Literal["auto"],
+    name: str = "gpu_batch_size",
+) -> None:
+    """Validate an explicit batch size or the adaptive ``auto`` sentinel."""
+    if value == AUTO_BATCH_SIZE:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer or 'auto'")
+
+
+def validate_max_batch_size(
+    value: int,
+    name: str = "max_gpu_batch_size",
+) -> None:
+    """Validate an adaptive batching upper bound."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")

--- a/src/hashformers/beamsearch/minicons_lm.py
+++ b/src/hashformers/beamsearch/minicons_lm.py
@@ -6,12 +6,17 @@ import warnings
 import torch
 from minicons import scorer
 
+from hashformers.batching import (
+    AUTO_BATCH_SIZE,
+    DEFAULT_AUTO_BATCH_SIZE,
+    DEFAULT_MAX_BATCH_SIZE,
+    validate_batch_size,
+    validate_max_batch_size,
+)
+
 
 LOGGER = logging.getLogger(__name__)
 
-AUTO_BATCH_SIZE = "auto"
-DEFAULT_AUTO_BATCH_SIZE = 64
-DEFAULT_MAX_BATCH_SIZE = 512
 MIN_THROUGHPUT_IMPROVEMENT = 0.05
 MIN_MEMORY_HEADROOM = 0.20
 
@@ -28,20 +33,6 @@ def ensure_tokenizer_compatibility(tokenizer):
     if not callable(getattr(tokenizer, "batch_encode_plus", None)):
         tokenizer.batch_encode_plus = tokenizer.__call__
     return tokenizer
-
-
-def validate_batch_size(value, name="gpu_batch_size"):
-    """Validate an explicit batch size or the adaptive ``auto`` sentinel."""
-    if value == AUTO_BATCH_SIZE:
-        return
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        raise ValueError(f"{name} must be a positive integer or 'auto'")
-
-
-def validate_max_batch_size(value, name="max_gpu_batch_size"):
-    """Validate an adaptive batching upper bound."""
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        raise ValueError(f"{name} must be a positive integer")
 
 
 class MiniconsLM(object):

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -2,6 +2,8 @@
 
 """
 
+from __future__ import annotations
+
 import csv
 import hashlib
 import inspect
@@ -20,25 +22,29 @@ from fnmatch import fnmatchcase
 from itertools import islice
 from pathlib import Path
 from threading import Lock
-from typing import Literal, TextIO
+from typing import TYPE_CHECKING, Any, Literal, TextIO
 
 import anyio
-import torch
-from huggingface_hub import HfApi, snapshot_download
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 from typing_extensions import NotRequired, TypedDict
 
-from hashformers.beamsearch.data_structures import ProbabilityDictionary
-from hashformers.beamsearch.minicons_lm import (
+from hashformers.batching import (
     DEFAULT_MAX_BATCH_SIZE,
     validate_batch_size,
     validate_max_batch_size,
 )
-from hashformers.segmenter import BaseWordSegmenter
-from hashformers.segmenter.auto import TransformerWordSegmenter
-from hashformers.segmenter.data_structures import WordSegmenterOutput
+
+if TYPE_CHECKING:
+    from huggingface_hub import HfApi
+
+    from hashformers.segmenter.auto import TransformerWordSegmenter
+    from hashformers.segmenter.data_structures import WordSegmenterOutput
+else:
+    HfApi = Any
+    TransformerWordSegmenter = Any
+    WordSegmenterOutput = Any
 
 RankingStrategy = Literal["auto", "segmenter", "reranker", "ensemble"]
 ResolvedRankingStrategy = Literal["segmenter", "reranker", "ensemble"]
@@ -78,9 +84,6 @@ HUB_MODEL_FILE_PATTERNS = (
 )
 SUPPORTED_SCORER_TYPES = frozenset(
     {"gpt2", "bert", "incremental", "masked", "seq2seq"}
-)
-HUB_SUPPORTS_PARAMETER_FILTER = (
-    "num_parameters" in inspect.signature(HfApi.list_models).parameters
 )
 JOB_APPLICATION_ID = 0x48464D52
 JOB_SCHEMA_VERSION = 1
@@ -1279,12 +1282,19 @@ def _resolve_device(device: str, inherited_device: str | None = None) -> str:
         Concrete device string accepted by Hashformers.
     """
     if device == "auto":
-        return "cuda" if torch.cuda.is_available() else "cpu"
+        return "cuda" if _cuda_is_available() else "cpu"
     if device == "inherit":
         if inherited_device is None:
             raise ValueError("inherit requires a resolved segmenter device")
         return inherited_device
     return device
+
+
+def _cuda_is_available() -> bool:
+    """Load PyTorch only when automatic device selection is requested."""
+    import torch
+
+    return torch.cuda.is_available()
 
 
 def _validate_hub_revision(revision: str, name: str) -> None:
@@ -1697,12 +1707,40 @@ def _fetch_and_validate_hub_model(
     )
 
 
+def _create_hub_api() -> HfApi:
+    """Construct the anonymous Hub client only for model operations."""
+    from huggingface_hub import HfApi
+
+    return HfApi()
+
+
+def _hub_supports_parameter_filter() -> bool:
+    """Inspect the installed Hub API lazily for server-side size filtering."""
+    from huggingface_hub import HfApi
+
+    return "num_parameters" in inspect.signature(HfApi.list_models).parameters
+
+
+def _download_model_snapshot(**kwargs) -> str:
+    """Download one pinned model snapshot without importing Hub at startup."""
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(**kwargs)
+
+
+def _create_transformer_segmenter(**kwargs) -> TransformerWordSegmenter:
+    """Construct the Transformer runtime only for the first inference call."""
+    from hashformers.segmenter.auto import TransformerWordSegmenter
+
+    return TransformerWordSegmenter(**kwargs)
+
+
 def _pinned_model_path(repository_id: str, revision: str | None) -> str:
     """Resolve an exact validated Hub revision into the local cache lazily."""
     if revision is None:
         return repository_id
     try:
-        return snapshot_download(
+        return _download_model_snapshot(
             repo_id=repository_id,
             revision=revision,
             token=False,
@@ -1744,7 +1782,7 @@ def get_segmenter() -> TransformerWordSegmenter:
                     if _server_config.reranker_model is not None
                     else None
                 )
-                _segmenter = TransformerWordSegmenter(
+                _segmenter = _create_transformer_segmenter(
                     segmenter_model_name_or_path=segmenter_path,
                     segmenter_model_type=_server_config.segmenter_model_type,
                     segmenter_device=segmenter_device,
@@ -2075,6 +2113,8 @@ def _run_transformer_pipeline(
     Returns:
         Selected segmentations and every component ranking that ran.
     """
+    from hashformers.segmenter import BaseWordSegmenter
+
     use_reranker, use_ensembler = _strategy_flags(strategy)
     return BaseWordSegmenter.segment(
         segmenter,
@@ -2965,7 +3005,7 @@ def discover_huggingface_models(
     if role not in {"segmenter", "reranker"}:
         raise ValueError("role must be segmenter or reranker")
     _validate_at_most(limit, MAX_MODEL_CANDIDATES, "limit")
-    api = HfApi()
+    api = _create_hub_api()
     list_options = {
         "filter": ("transformers", normalized_language),
         "gated": False,
@@ -2976,7 +3016,7 @@ def discover_huggingface_models(
         "fetch_config": True,
         "token": False,
     }
-    if HUB_SUPPORTS_PARAMETER_FILTER:
+    if _hub_supports_parameter_filter():
         list_options["num_parameters"] = (
             f"max:{_server_config.max_model_parameters}"
         )
@@ -3123,7 +3163,7 @@ def configure_models(
                 )
             return {"configured": True, "models": _selected_models_payload()}
 
-        api = HfApi()
+        api = _create_hub_api()
         segmenter_metadata = _fetch_and_validate_hub_model(
             api,
             segmenter_model,
@@ -3876,6 +3916,9 @@ def rank_candidates(
         Returns:
             None.
         """
+        from hashformers.beamsearch.data_structures import ProbabilityDictionary
+        from hashformers.segmenter.data_structures import WordSegmenterOutput
+
         combined_scores = {
             segmentation: score
             for item in batch

--- a/tests/test_mcp_model_selection.py
+++ b/tests/test_mcp_model_selection.py
@@ -264,7 +264,7 @@ def test_discover_huggingface_models_validates_languages_and_exact_revisions(
         language=language,
     )
 
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         result = discover_huggingface_models(language, "segmenter")
 
     assert result["language"] == language
@@ -286,7 +286,7 @@ def test_discover_huggingface_models_validates_languages_and_exact_revisions(
         fetch_config=True,
         token=False,
     )
-    if mcp_server.HUB_SUPPORTS_PARAMETER_FILTER:
+    if mcp_server._hub_supports_parameter_filter():
         expected_list_options["num_parameters"] = (
             f"max:{mcp_server.DEFAULT_MAX_MODEL_PARAMETERS}"
         )
@@ -346,7 +346,7 @@ def test_discovery_skips_unavailable_gated_oversize_custom_and_unloadable_models
         return info
 
     api.model_info.side_effect = model_info
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         result = discover_huggingface_models("en", "segmenter")
 
     assert result["candidates"] == []
@@ -360,7 +360,7 @@ def test_failed_discovery_leaves_deferred_server_unconfigured(tmp_path):
     api = Mock()
     api.list_models.side_effect = OSError("Hub unavailable")
 
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         with pytest.raises(ValueError, match="model discovery failed"):
             discover_huggingface_models("en", "segmenter")
 
@@ -390,7 +390,7 @@ def test_discovery_is_deterministic_and_hard_caps_results(tmp_path):
         repository_id
     ]
 
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         result = discover_huggingface_models("en", "segmenter", limit=2)
 
     assert [candidate["repository_id"] for candidate in result["candidates"]] == [
@@ -406,9 +406,11 @@ def test_configure_models_is_validated_lazy_idempotent_and_immutable(tmp_path):
     _enable_deferred(tmp_path)
     api = _configured_api(include_reranker=True)
     with (
-        patch("hashformers.mcp_server.HfApi", return_value=api),
-        patch("hashformers.mcp_server.snapshot_download") as download,
-        patch("hashformers.mcp_server.TransformerWordSegmenter") as constructor,
+        patch("hashformers.mcp_server._create_hub_api", return_value=api),
+        patch("hashformers.mcp_server._download_model_snapshot") as download,
+        patch(
+            "hashformers.mcp_server._create_transformer_segmenter"
+        ) as constructor,
     ):
         first = configure_models(
             "example/segmenter",
@@ -454,7 +456,7 @@ def test_configuration_failure_does_not_publish_a_partial_selection(tmp_path):
         reranker,
     ]
 
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         with pytest.raises(ValueError, match="gated Hub models"):
             configure_models(
                 "example/segmenter",
@@ -500,7 +502,7 @@ def test_configuration_fails_closed_for_unsupported_or_unbounded_models(
     api = Mock()
     api.model_info.return_value = info
 
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         with pytest.raises(ValueError, match=message):
             configure_models("example/segmenter", SEGMENTER_REVISION)
 
@@ -512,7 +514,7 @@ def test_concurrent_identical_configuration_validates_and_publishes_once(tmp_pat
     """Serialize concurrent configuration calls around one atomic validation."""
     _enable_deferred(tmp_path)
     api = _configured_api()
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         with ThreadPoolExecutor(max_workers=4) as executor:
             results = list(
                 executor.map(
@@ -532,17 +534,17 @@ def test_concurrent_lazy_loading_retains_one_pinned_segmenter_instance(tmp_path)
     """Ensure concurrent inference cannot create multiple resident models."""
     _enable_deferred(tmp_path)
     api = _configured_api()
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         configure_models("example/segmenter", SEGMENTER_REVISION)
 
     resident = object()
     with (
         patch(
-            "hashformers.mcp_server.snapshot_download",
+            "hashformers.mcp_server._download_model_snapshot",
             return_value="/cache/exact-segmenter",
         ) as download,
         patch(
-            "hashformers.mcp_server.TransformerWordSegmenter",
+            "hashformers.mcp_server._create_transformer_segmenter",
             return_value=resident,
         ) as constructor,
     ):
@@ -566,7 +568,7 @@ def test_segmentation_response_records_selected_repository_and_revision(tmp_path
     """Expose exact model identity with every interactive model result."""
     _enable_deferred(tmp_path)
     api = _configured_api()
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         configure_models("example/segmenter", SEGMENTER_REVISION)
 
     rank = pd.DataFrame(
@@ -595,7 +597,7 @@ def test_file_job_status_checkpoint_and_output_record_exact_revision(tmp_path):
     input_path.write_text("#icecold\n", encoding="utf-8")
     _enable_deferred(tmp_path)
     api = _configured_api()
-    with patch("hashformers.mcp_server.HfApi", return_value=api):
+    with patch("hashformers.mcp_server._create_hub_api", return_value=api):
         configure_models("example/segmenter", SEGMENTER_REVISION)
 
     started = start_hashtag_file_job(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
+import os
 import sqlite3
 import stat
+import subprocess
+import sys
 from pathlib import Path
 from threading import Event, get_ident
 from unittest.mock import AsyncMock, Mock, patch
@@ -10,6 +13,9 @@ import pandas as pd
 import pytest
 
 Client = pytest.importorskip("mcp").Client
+ClientSession = pytest.importorskip("mcp").ClientSession
+StdioServerParameters = pytest.importorskip("mcp").StdioServerParameters
+stdio_client = pytest.importorskip("mcp").stdio_client
 
 import hashformers.mcp_server as mcp_server
 from hashformers.mcp_server import (
@@ -24,12 +30,27 @@ from hashformers.mcp_server import (
     segment_hashtags,
     start_hashtag_file_job,
 )
+from hashformers.segmenter import BaseWordSegmenter
 from hashformers.segmenter.data_structures import WordSegmenterOutput
 
 requires_secure_file_jobs = pytest.mark.skipif(
     not mcp_server.SUPPORTS_SECURE_FILE_JOBS,
     reason="requires Linux descriptor-backed file operations",
 )
+ROOT = Path(__file__).parent.parent
+
+
+def _source_environment():
+    """Return an environment that imports this checkout in child processes."""
+    environment = os.environ.copy()
+    source_path = str(ROOT / "src")
+    existing_path = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = (
+        f"{source_path}{os.pathsep}{existing_path}"
+        if existing_path
+        else source_path
+    )
+    return environment
 
 
 @pytest.fixture(autouse=True)
@@ -138,7 +159,9 @@ def test_get_segmenter_forwards_complete_startup_configuration_once():
         )
     )
 
-    with patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class:
+    with patch(
+        "hashformers.mcp_server._create_transformer_segmenter"
+    ) as segmenter_class:
         first = get_segmenter()
         second = get_segmenter()
 
@@ -164,8 +187,10 @@ def test_get_segmenter_resolves_auto_device_for_both_models():
     configure_server(ServerConfig(reranker_model="custom/bert"))
 
     with (
-        patch("hashformers.mcp_server.torch.cuda.is_available", return_value=True),
-        patch("hashformers.mcp_server.TransformerWordSegmenter") as segmenter_class,
+        patch("hashformers.mcp_server._cuda_is_available", return_value=True),
+        patch(
+            "hashformers.mcp_server._create_transformer_segmenter"
+        ) as segmenter_class,
     ):
         get_segmenter()
 
@@ -250,7 +275,7 @@ def test_run_transformer_pipeline_delegates_every_option_to_base_segmenter():
     """Verify the compatibility helper forwards every library option exactly.
 
     """
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     segmenter_run = object()
     preprocessing_kwargs = {
         "lower": True,
@@ -260,7 +285,7 @@ def test_run_transformer_pipeline_delegates_every_option_to_base_segmenter():
     expected = _mock_output()
 
     with patch.object(
-        mcp_server.BaseWordSegmenter,
+        BaseWordSegmenter,
         "segment",
         return_value=expected,
     ) as base_segment:
@@ -294,7 +319,7 @@ def test_segment_hashtags_separates_beam_width_from_response_limit():
     """Verify asking for fewer results does not narrow beam search.
 
     """
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     pipeline = Mock(return_value=_mock_output())
 
     with (
@@ -362,7 +387,7 @@ def test_segment_hashtags_returns_all_component_rankings():
 
     """
     configure_server(ServerConfig(reranker_model="custom/bert"))
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     pipeline = Mock(return_value=_mock_output(include_pipeline=True))
 
     with (
@@ -405,7 +430,7 @@ def test_auto_strategy_uses_reranker_only_when_configured():
     """Verify auto preserves the Python pipeline's default selection.
 
     """
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     pipeline = Mock(return_value=_mock_output())
 
     with (
@@ -546,7 +571,7 @@ def test_hashtag_file_job_resumes_deduplicates_and_returns_only_summary(tmp_path
         "#icecold\n#benfica\n#icecold\n#mouraria\n#benfica\n",
         encoding="utf-8",
     )
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     pipeline = Mock(side_effect=_mock_batch_output)
     context = Mock()
     context.report_progress = AsyncMock()
@@ -975,7 +1000,7 @@ def test_continue_hashtag_file_job_uses_checkpoint_after_source_changes(tmp_path
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
@@ -999,7 +1024,7 @@ def test_continue_hashtag_file_job_reconciles_completed_output(tmp_path):
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch(
             "hashformers.mcp_server._run_transformer_pipeline",
@@ -1065,7 +1090,7 @@ def test_file_job_never_overwrites_a_destination_created_during_publish(tmp_path
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch(
             "hashformers.mcp_server._run_transformer_pipeline",
@@ -1196,7 +1221,7 @@ def test_file_job_publication_stays_bound_to_authorized_directory(tmp_path):
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch(
             "hashformers.mcp_server._run_transformer_pipeline",
@@ -1261,7 +1286,7 @@ def test_concurrent_continuations_do_not_duplicate_inference(tmp_path):
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
@@ -1340,7 +1365,7 @@ def test_cancelled_continuation_keeps_its_checkpoint_claim(tmp_path):
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
@@ -1384,7 +1409,7 @@ def test_large_file_finalization_runs_outside_the_event_loop(tmp_path):
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch(
             "hashformers.mcp_server._run_transformer_pipeline",
@@ -1573,7 +1598,7 @@ def test_rank_candidates_passes_precomputed_run_to_reranker_pipeline():
 
     """
     configure_server(ServerConfig(reranker_model="custom/bert"))
-    segmenter = mcp_server.BaseWordSegmenter()
+    segmenter = BaseWordSegmenter()
     pipeline = Mock(
         return_value=WordSegmenterOutput(
             output=["i ce cold"],
@@ -1637,7 +1662,7 @@ def test_rank_candidates_batches_candidate_sets_for_reranking():
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
@@ -1698,7 +1723,7 @@ def test_rank_candidates_isolates_colliding_candidate_sets():
     with (
         patch(
             "hashformers.mcp_server.get_segmenter",
-            return_value=mcp_server.BaseWordSegmenter(),
+            return_value=BaseWordSegmenter(),
         ),
         patch("hashformers.mcp_server._run_transformer_pipeline", pipeline),
     ):
@@ -1777,6 +1802,65 @@ def test_rank_candidates_rejects_invalid_candidate_sets(candidate_sets):
             rank_candidates(candidate_sets, ranking_strategy="segmenter")
 
     get_model.assert_not_called()
+
+
+def test_mcp_module_import_does_not_load_model_runtime():
+    """Keep the MCP handshake independent of ML and Hub imports."""
+    code = """
+import sys
+import hashformers.mcp_server
+
+blocked = {"huggingface_hub", "minicons", "pandas", "torch", "transformers"}
+loaded = sorted(blocked.intersection(sys.modules))
+if loaded:
+    raise SystemExit(f"eagerly loaded runtime dependencies: {loaded}")
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=_source_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_spawned_stdio_server_initializes_within_startup_budget(tmp_path):
+    """Exercise the real console bootstrap below the client timeout."""
+
+    async def list_tools():
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                "-m",
+                "hashformers.mcp_server",
+                "--file-root",
+                str(tmp_path),
+            ],
+            cwd=ROOT,
+            env=_source_environment(),
+        )
+        async with stdio_client(
+            parameters,
+            errlog=subprocess.DEVNULL,
+        ) as streams:
+            async with ClientSession(*streams) as session:
+                await session.initialize()
+                return await session.list_tools()
+
+    listed = asyncio.run(asyncio.wait_for(list_tools(), timeout=10))
+
+    assert {tool.name for tool in listed.tools} == {
+        "sample_hashtag_file",
+        "discover_huggingface_models",
+        "configure_models",
+        "segment_hashtags",
+        "start_hashtag_file_job",
+        "continue_hashtag_file_job",
+        "rank_candidates",
+    }
 
 
 def test_mcp_server_exposes_complete_structured_surface():

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -1,4 +1,7 @@
+import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 
 import setuptools
@@ -7,6 +10,19 @@ import hashformers
 
 
 ROOT = Path(__file__).parent.parent
+
+
+def _source_environment():
+    """Return an environment that imports this checkout instead of an old wheel."""
+    environment = os.environ.copy()
+    source_path = str(ROOT / "src")
+    existing_path = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = (
+        f"{source_path}{os.pathsep}{existing_path}"
+        if existing_path
+        else source_path
+    )
+    return environment
 
 
 def read_setup_kwargs(monkeypatch):
@@ -44,6 +60,64 @@ def test_legacy_regex_and_tweet_apis_are_not_exported():
         "HashtagContainer",
     ):
         assert not hasattr(hashformers, name)
+
+
+def test_package_import_does_not_load_model_runtime():
+    """Keep lightweight submodules usable without importing the ML stack."""
+    code = """
+import sys
+import hashformers
+
+blocked = {"minicons", "pandas", "torch", "transformers"}
+loaded = sorted(blocked.intersection(sys.modules))
+if loaded:
+    raise SystemExit(f"eagerly loaded model dependencies: {loaded}")
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=_source_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_documented_transformer_export_resolves_lazily():
+    """Preserve the documented top-level model import after lazy loading."""
+    from hashformers import TransformerWordSegmenter
+    from hashformers.segmenter.auto import (
+        TransformerWordSegmenter as DirectTransformerWordSegmenter,
+    )
+
+    assert TransformerWordSegmenter is DirectTransformerWordSegmenter
+
+
+def test_lazy_package_preserves_historical_public_names():
+    """Keep the pre-lazy top-level import surface discoverable."""
+    assert set(hashformers.__all__) == {
+        "Any",
+        "BaseSegmenter",
+        "BaseWordSegmenter",
+        "Beamsearch",
+        "DEFAULT_MAX_BATCH_SIZE",
+        "ReciprocalRankFusionEnsembler",
+        "Reranker",
+        "Top2_Ensembler",
+        "TransformerWordSegmenter",
+        "WordSegmenterOutput",
+        "base_segmenter",
+        "beamsearch",
+        "data_structures",
+        "enforce_prob_dict",
+        "ensemble",
+        "evaluation",
+        "experiments",
+        "segmenter",
+    }
+    assert set(hashformers.__all__).issubset(dir(hashformers))
 
 
 def test_mcp_server_is_an_optional_extra(monkeypatch):


### PR DESCRIPTION
## Summary

- preserve Hashformers' historical top-level API through lazy package exports
- move batch-size defaults and validation into a dependency-free module
- defer PyTorch, Transformers, Minicons, pandas-backed, and Hugging Face imports until the relevant MCP tool needs them
- add fresh-process import checks and a real spawned stdio initialization regression

## Root cause

Model construction was already lazy, but importing `hashformers.mcp_server` first executed the package's wildcard exports and then imported the complete ML and Hub runtime directly. On the development environment, `import hashformers` took 41.6 seconds, so the server could not reach `mcp.run()` before the client's 30-second startup deadline.

The new bootstrap path imports only MCP/schema and dependency-free Hashformers configuration. Existing model loading remains protected by the process-wide singleton lock and begins on the first inference call.

## Impact

A spawned stdio server now completes initialization and `tools/list` in 3.69 seconds, without requiring users to set `startup_timeout_sec`. Importing the MCP module does not load `torch`, `transformers`, `minicons`, `pandas`, or `huggingface_hub`.

Documented usage such as:

```python
from hashformers import TransformerWordSegmenter
```

continues to work, and the complete historical top-level name set remains discoverable.

## Validation

Passing checks:

- issue-focused package, MCP, model-loading, and adaptive-batching tests: 33 passed
- complete model-selection suite: 21 passed
- fresh-process MCP import and spawned stdio startup regressions: 2 passed
- scoped final publish checks: 7 passed
- `git diff --check`

CPU-compatible full-suite audit:

- 207 passed
- 7 unrelated existing failures remain in published benchmark artifact comparisons, stale RRF expectations, and README expectations
- `tests/test_segmenter.py` was excluded because it deliberately raises when CUDA is unavailable

Closes #88
