### PR TITLE
Finish RRF integration with complete MCP regression coverage

### DIFF
--- a/.agents/skills/segment-hashtags/SKILL.md
+++ b/.agents/skills/segment-hashtags/SKILL.md
@@ -121,7 +121,14 @@ For `segment_hashtags` and file jobs:
 - `ranking_strategy` can be `auto`, `segmenter`, `reranker`, or `ensemble`.
   Reranker and ensemble strategies require a reranker configured for the MCP
   process, either at startup or through authorized deferred selection.
-- `alpha` and `beta` configure ensemble selection.
+- `fusion_method` defaults to `top2`, where `alpha` and `beta` configure the
+  legacy ensemble. Set `fusion_method="rrf"` only with `ensemble` selection and
+  a configured reranker.
+- RRF defaults to `rrf_k=60` and equal `fusion_weights` of `segmenter=1.0` and
+  `reranker=1.0`. Custom weights must contain exactly those two nonnegative
+  values and cannot both be zero. RRF combines full component rankings, and
+  its serialized score is negative because Hashformers scores are
+  lower-is-better.
 - `lower`, `remove_hashtag`, and `hashtag_character` configure preprocessing.
 - `include_component_rankings=true` returns segmenter, reranker, and ensemble
   rankings that actually ran.
@@ -186,6 +193,10 @@ Call `rank_candidates` with candidate sets shaped as:
 
 Use `segmenter` to select from supplied scores without loading a model. Use
 `reranker` or `ensemble` only when the server has a configured reranker.
+For full-list RRF, use `ranking_strategy="ensemble"`, `fusion_method="rrf"`,
+and optionally `rrf_k` plus `fusion_weights`. Request
+`include_component_rankings=true` when the user needs to inspect how the
+segmenter, reranker, and fused ranks produced the selection.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 **Fast, local, multilingual hashtag and identifier segmentation using
 Transformer language models and beam search.**
 
+![Hashformers terminal demo](docs/assets/demo-8s.gif)
+
 - **+37.5 percentage-point accuracy advantage** over Qwen3-0.6B on a
   [fixed 280-item multilingual benchmark](benchmarks/qwen/README.md)
 - **14.1 hashtags/second** on a single NVIDIA T4
@@ -76,6 +78,36 @@ ws = WordSegmenter(
 )
 ```
 
+### Reciprocal Rank Fusion
+
+When both a segmenter and reranker are configured, full-list reciprocal rank
+fusion (RRF) can combine every candidate instead of using the default legacy
+`top2` fusion:
+
+```python
+ranked = ws.segment(
+    ["#icecold"],
+    fusion_method="rrf",
+    rrf_k=60,
+    fusion_weights={"segmenter": 1.0, "reranker": 2.0},
+    return_ranks=True,
+)
+```
+
+For candidate `c`, Hashformers computes
+`RRF(c) = sum(w_i / (rrf_k + rank_i(c)))`. Ranks are one-based competition
+ranks within each input, so tied component scores share the same rank. A
+candidate missing from one component contributes zero for that component.
+Fused ties fall back to the segmenter rank, then reranker rank, then stable
+input order.
+
+Hashformers stores `-RRF(c)` because all its public ranking tables use
+lower-is-better scores. The defaults are `rrf_k=60` and equal
+`segmenter=1.0`, `reranker=1.0` weights. `fusion_method="top2"` remains the
+default and continues to use `alpha` and `beta`; RRF only affects selection
+when a reranker is present and ensemble selection is active. Requesting RRF
+without both raises `ValueError` rather than reporting fusion that did not run.
+
 ### MCP and Agent Skill
 
 #### Install the MCP Server
@@ -106,6 +138,29 @@ Ask the agent directly:
 
 > Use Hashformers to segment `#weneedanationalpark` and `#icecold`. Return up
 > to three candidates for each hashtag.
+
+To request default RRF through MCP, configure the server with
+`--reranker-model` and pass:
+
+```json
+{
+  "hashtags": ["#weneedanationalpark", "#icecold"],
+  "ranking_strategy": "ensemble",
+  "fusion_method": "rrf"
+}
+```
+
+Custom rank damping and weights use the same contract for
+`segment_hashtags`, `start_hashtag_file_job`, and `rank_candidates`:
+
+```json
+{
+  "ranking_strategy": "ensemble",
+  "fusion_method": "rrf",
+  "rrf_k": 0,
+  "fusion_weights": {"segmenter": 1.0, "reranker": 2.0}
+}
+```
 
 #### Process Large Files
 

--- a/src/hashformers/ensemble/rrf_fusion.py
+++ b/src/hashformers/ensemble/rrf_fusion.py
@@ -46,7 +46,12 @@ def _competition_ranks(probability_dictionary):
 
 
 def reciprocal_rank_fusion(rankings: Sequence, weights=None, rrf_k=60):
-    """Fuse complete lower-is-better rankings and return lower-is-better scores."""
+    """Fuse complete rankings with ``sum(weight / (k + rank))``.
+
+    Component ranks are one-based competition ranks. Missing candidates add
+    zero, fused ties fall back to component ranks and stable input order, and
+    scores are negated to preserve Hashformers' lower-is-better convention.
+    """
     if (
         not isinstance(rankings, Sequence)
         or isinstance(rankings, (str, bytes))

--- a/src/hashformers/mcp_server.py
+++ b/src/hashformers/mcp_server.py
@@ -98,6 +98,21 @@ JOB_METADATA_KEYS = (
     "server_config",
     "run_options",
 )
+JOB_RUN_OPTION_KEYS = (
+    "top_k",
+    "steps",
+    "ranking_strategy",
+    "alpha",
+    "beta",
+    "fusion_method",
+    "rrf_k",
+    "fusion_weights",
+    "lower",
+    "remove_hashtag",
+    "hashtag_character",
+    "max_candidates",
+    "include_component_rankings",
+)
 JOB_TABLE_SCHEMAS = {
     "metadata": (
         ("key", "TEXT", 0, 1),
@@ -172,6 +187,7 @@ class SegmentationResult(TypedDict):
         normalized_input: Text after Hashformers preprocessing.
         selected_segmentation: Highest-ranked segmentation.
         ranking_strategy: Component that selected the result.
+        fusion_method: Fusion algorithm requested for ensemble selection.
         candidates: Ranked candidates from the selected component.
         component_rankings: Optional rankings for every component that ran.
     """
@@ -300,6 +316,7 @@ class FileJobStatus(TypedDict):
         reranker_model: Optional model used for reranking.
         reranker_revision: Exact Hub revision used by the reranker, when pinned.
         ranking_strategy: Component used to select output segmentations.
+        fusion_method: Fusion algorithm persisted for ensemble selection.
     """
 
     job_path: str
@@ -2043,6 +2060,63 @@ def _validate_fusion_options(
         raise ValueError("fusion weights must not all be zero")
 
 
+def _validate_fusion_strategy(
+    fusion_method: FusionMethod,
+    strategy: ResolvedRankingStrategy,
+) -> None:
+    """Ensure an RRF request will actually execute an ensemble."""
+    if fusion_method == "rrf" and strategy != "ensemble":
+        raise ValueError(
+            "fusion_method=rrf requires ranking_strategy=ensemble and a "
+            "configured reranker"
+        )
+
+
+def _normalized_fusion_weights(
+    fusion_weights: Mapping[str, float] | None,
+) -> dict[str, float]:
+    """Return explicit, JSON-safe segmenter and reranker weights."""
+    weights = (
+        {"segmenter": 1.0, "reranker": 1.0}
+        if fusion_weights is None
+        else fusion_weights
+    )
+    return {name: float(weights[name]) for name in ("segmenter", "reranker")}
+
+
+def _load_job_run_options(serialized: str) -> dict[str, Any]:
+    """Load and validate the immutable inference contract in a checkpoint."""
+    try:
+        run_options = json.loads(serialized)
+        if not isinstance(run_options, dict) or set(run_options) != set(
+            JOB_RUN_OPTION_KEYS
+        ):
+            raise ValueError
+        if any(
+            not isinstance(run_options[name], bool)
+            for name in ("lower", "remove_hashtag", "include_component_rankings")
+        ):
+            raise ValueError
+        strategy = run_options["ranking_strategy"]
+        if strategy not in {"segmenter", "reranker", "ensemble"}:
+            raise ValueError
+        _validate_runtime_options(
+            run_options["top_k"],
+            run_options["steps"],
+            run_options["alpha"],
+            run_options["beta"],
+            run_options["max_candidates"],
+            run_options["hashtag_character"],
+            run_options["fusion_method"],
+            run_options["rrf_k"],
+            run_options["fusion_weights"],
+        )
+        _validate_fusion_strategy(run_options["fusion_method"], strategy)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("job checkpoint contains invalid run options") from error
+    return run_options
+
+
 def _resolve_ranking_strategy(strategy: RankingStrategy) -> ResolvedRankingStrategy:
     """Resolve an explicit pipeline component for result selection.
 
@@ -2106,6 +2180,9 @@ def _run_transformer_pipeline(
         steps: Number of beam-search expansion steps.
         alpha: Segmenter-score ensemble weight.
         beta: Reranker-score ensemble weight.
+        fusion_method: ``top2`` compatibility fusion or full-list RRF.
+        rrf_k: Nonnegative RRF rank constant.
+        fusion_weights: Optional RRF component weights.
         strategy: Component used for final selection.
         preprocessing_kwargs: Options forwarded to input preprocessing.
         segmenter_run: Optional precomputed candidate scores.
@@ -2228,6 +2305,7 @@ def _serialize_word_output(
         strategy: Component that selected each result.
         max_candidates: Maximum candidates returned per component.
         include_component_rankings: Whether to include every component rank.
+        fusion_method: Fusion algorithm reported in each serialized result.
 
     Returns:
         Per-input JSON-safe segmentation results.
@@ -2676,7 +2754,7 @@ def _file_job_status(
     total, unique, processed = _job_counts(connection)
     remaining = unique - processed
     server_config = json.loads(metadata["server_config"])
-    run_options = json.loads(metadata["run_options"])
+    run_options = _load_job_run_options(metadata["run_options"])
     return {
         "job_path": str(job_path),
         "input_path": metadata["input_path"],
@@ -3228,6 +3306,9 @@ def segment_hashtags(
         ranking_strategy: Component used to select the final segmentation.
         alpha: Segmenter-score weight used by the ensemble.
         beta: Reranker-score weight used by the ensemble.
+        fusion_method: ``top2`` compatibility fusion or full-list RRF.
+        rrf_k: Nonnegative constant added to each reciprocal rank.
+        fusion_weights: Optional segmenter and reranker RRF weights.
         lower: Whether to lowercase inputs before segmentation.
         remove_hashtag: Whether to strip leading hashtag characters.
         hashtag_character: Character stripped during preprocessing.
@@ -3256,6 +3337,7 @@ def segment_hashtags(
     )
     _require_models_configured()
     strategy = _resolve_ranking_strategy(ranking_strategy)
+    _validate_fusion_strategy(fusion_method, strategy)
     normalized = _normalize_inputs(
         hashtags,
         lower=lower,
@@ -3334,6 +3416,9 @@ def start_hashtag_file_job(
         ranking_strategy: Component used to select final segmentations.
         alpha: Segmenter-score weight used by the ensemble.
         beta: Reranker-score weight used by the ensemble.
+        fusion_method: ``top2`` compatibility fusion or full-list RRF.
+        rrf_k: Nonnegative constant added to each reciprocal rank.
+        fusion_weights: Optional segmenter and reranker RRF weights.
         lower: Whether to lowercase inputs before segmentation.
         remove_hashtag: Whether to strip leading hashtag characters.
         hashtag_character: Character stripped during preprocessing.
@@ -3373,6 +3458,7 @@ def start_hashtag_file_job(
     )
     _require_models_configured()
     resolved_strategy = _resolve_ranking_strategy(ranking_strategy)
+    _validate_fusion_strategy(fusion_method, resolved_strategy)
 
     source = _resolve_file_path(input_path, "input_path", must_exist=True)
     if not source.is_file():
@@ -3414,11 +3500,7 @@ def start_hashtag_file_job(
         "beta": float(beta),
         "fusion_method": fusion_method,
         "rrf_k": float(rrf_k),
-        "fusion_weights": dict(
-            {"segmenter": 1.0, "reranker": 1.0}
-            if fusion_weights is None
-            else fusion_weights
-        ),
+        "fusion_weights": _normalized_fusion_weights(fusion_weights),
         "lower": lower,
         "remove_hashtag": remove_hashtag,
         "hashtag_character": hashtag_character,
@@ -3653,7 +3735,7 @@ def _continue_file_job_sync(
             raise ValueError(
                 "MCP model configuration changed since the job was started"
             )
-        run_options = json.loads(metadata["run_options"])
+        run_options = _load_job_run_options(metadata["run_options"])
         pending_rows = connection.execute(
             """
             SELECT substr(normalized, 1, ?),
@@ -3811,6 +3893,9 @@ def rank_candidates(
         ranking_strategy: Component used to select each result.
         alpha: Segmenter-score weight used by the ensemble.
         beta: Reranker-score weight used by the ensemble.
+        fusion_method: ``top2`` compatibility fusion or full-list RRF.
+        rrf_k: Nonnegative constant added to each reciprocal rank.
+        fusion_weights: Optional segmenter and reranker RRF weights.
         max_candidates: Response limit per ranking, capped at 64.
         include_component_rankings: Whether to return every component rank.
 
@@ -3828,6 +3913,7 @@ def rank_candidates(
     _validate_fusion_options(fusion_method, rrf_k, fusion_weights)
     _validate_max_candidates(max_candidates)
     strategy = _resolve_ranking_strategy(ranking_strategy)
+    _validate_fusion_strategy(fusion_method, strategy)
 
     prepared = []
     total_candidates = 0

--- a/src/hashformers/segmenter/segmenter.py
+++ b/src/hashformers/segmenter/segmenter.py
@@ -99,6 +99,18 @@ class BaseWordSegmenter(BaseSegmenter):
         Returns:
             Returns the segmented words. If return_ranks is True, also returns the segmenter_rank, reranker_rank, and ensemble_rank.
         """
+        if fusion_method not in {"top2", "rrf"}:
+            raise ValueError("fusion_method must be top2 or rrf")
+        if fusion_method == "rrf" and not (
+            use_reranker
+            and self.reranker_model
+            and use_ensembler
+            and self.ensembler
+        ):
+            raise ValueError(
+                "fusion_method=rrf requires an active reranker and ensembler"
+            )
+
         word_list = super().preprocess(word_list, **preprocessing_kwargs)
 
         if segmenter_run is None:
@@ -116,9 +128,6 @@ class BaseWordSegmenter(BaseSegmenter):
 
         if use_reranker and self.reranker_model:
             reranker_run = self.reranker_model.rerank(segmenter_run, **reranker_kwargs)
-
-        if fusion_method not in {"top2", "rrf"}:
-            raise ValueError("fusion_method must be top2 or rrf")
 
         if use_reranker and self.reranker_model and use_ensembler and self.ensembler:
             ensembler = (

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ StdioServerParameters = pytest.importorskip("mcp").StdioServerParameters
 stdio_client = pytest.importorskip("mcp").stdio_client
 
 import hashformers.mcp_server as mcp_server
+from hashformers.beamsearch.data_structures import ProbabilityDictionary
 from hashformers.mcp_server import (
     ServerConfig,
     configure_server,
@@ -138,6 +139,39 @@ def _mock_batch_output(_segmenter, inputs, **kwargs):
         ]
     )
     return WordSegmenterOutput(output=normalized, segmenter_rank=rank)
+
+
+class _RrfSegmenterModel:
+    """Return three deterministic candidates for every three-character input."""
+
+    def run(self, word_list, **_kwargs):
+        scores = {}
+        for word in word_list:
+            scores[word] = 1.0
+            scores[f"{word[0]} {word[1:]}"] = 2.0
+            scores[f"{word[:2]} {word[2:]}"] = 3.0
+        return ProbabilityDictionary(scores)
+
+
+class _RrfRerankerModel:
+    """Prefer the segmenter's third candidate without changing its scores."""
+
+    def rerank(self, segmenter_run, **_kwargs):
+        scores = {}
+        for row in segmenter_run.to_dataframe().itertuples(index=False):
+            first_token_length = len(row.segmentation.split()[0])
+            scores[row.segmentation] = {2: 1.0, 3: 2.0, 1: 3.0}[
+                first_token_length
+            ]
+        return ProbabilityDictionary(scores)
+
+
+def _rrf_segmenter():
+    return BaseWordSegmenter(
+        segmenter=_RrfSegmenterModel(),
+        reranker=_RrfRerankerModel(),
+        ensembler=object(),
+    )
 
 
 def test_get_segmenter_forwards_complete_startup_configuration_once():
@@ -296,6 +330,9 @@ def test_run_transformer_pipeline_delegates_every_option_to_base_segmenter():
             steps=9,
             alpha=0.4,
             beta=0.6,
+            fusion_method="top2",
+            rrf_k=60,
+            fusion_weights=None,
             strategy="reranker",
             preprocessing_kwargs=preprocessing_kwargs,
             segmenter_run=segmenter_run,
@@ -309,6 +346,7 @@ def test_run_transformer_pipeline_delegates_every_option_to_base_segmenter():
         preprocessing_kwargs=preprocessing_kwargs,
         segmenter_kwargs={"topk": 20, "steps": 9},
         ensembler_kwargs={"alpha": 0.4, "beta": 0.6},
+        fusion_method="top2",
         use_reranker=True,
         use_ensembler=False,
         return_ranks=True,
@@ -342,6 +380,7 @@ def test_segment_hashtags_separates_beam_width_from_response_limit():
                 "normalized_input": "icecold",
                 "selected_segmentation": "ice cold",
                 "ranking_strategy": "segmenter",
+                "fusion_method": "top2",
                 "candidates": [
                     {"segmentation": "ice cold", "score": 1.0, "rank": 1},
                     {"segmentation": "i ce cold", "score": 2.0, "rank": 2},
@@ -372,6 +411,9 @@ def test_segment_hashtags_separates_beam_width_from_response_limit():
         steps=9,
         alpha=0.222,
         beta=0.111,
+        fusion_method="top2",
+        rrf_k=60,
+        fusion_weights=None,
         strategy="segmenter",
         preprocessing_kwargs={
             "lower": True,
@@ -403,6 +445,7 @@ def test_segment_hashtags_returns_all_component_rankings():
 
     item = result["results"][0]
     assert item["ranking_strategy"] == "ensemble"
+    assert item["fusion_method"] == "top2"
     assert [candidate["segmentation"] for candidate in item["candidates"]] == [
         "ice cold",
         "i ce cold",
@@ -417,6 +460,9 @@ def test_segment_hashtags_returns_all_component_rankings():
         steps=5,
         alpha=0.222,
         beta=0.111,
+        fusion_method="top2",
+        rrf_k=60,
+        fusion_weights=None,
         strategy="ensemble",
         preprocessing_kwargs={
             "lower": False,
@@ -424,6 +470,91 @@ def test_segment_hashtags_returns_all_component_rankings():
             "hashtag_character": "#",
         },
     )
+
+
+def test_segment_hashtags_runs_full_list_weighted_rrf_without_models():
+    """Verify MCP RRF can select beyond the segmenter's top two candidates."""
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+
+    with patch(
+        "hashformers.mcp_server.get_segmenter",
+        return_value=_rrf_segmenter(),
+    ):
+        result = segment_hashtags(
+            ["#abc"],
+            ranking_strategy="ensemble",
+            fusion_method="rrf",
+            rrf_k=0,
+            fusion_weights={"segmenter": 1.0, "reranker": 2.0},
+            max_candidates=3,
+            include_component_rankings=True,
+        )
+
+    item = result["results"][0]
+    assert item["selected_segmentation"] == "ab c"
+    assert item["fusion_method"] == "rrf"
+    assert [candidate["segmentation"] for candidate in item["candidates"]] == [
+        "ab c",
+        "abc",
+        "a bc",
+    ]
+    assert [candidate["score"] for candidate in item["candidates"]] == (
+        pytest.approx([-7 / 3, -2.0, -7 / 6])
+    )
+    assert [
+        candidate["segmentation"]
+        for candidate in item["component_rankings"]["segmenter"]
+    ] == ["abc", "a bc", "ab c"]
+    assert [
+        candidate["segmentation"]
+        for candidate in item["component_rankings"]["reranker"]
+    ] == ["ab c", "abc", "a bc"]
+    assert item["component_rankings"]["ensemble"] == item["candidates"]
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"fusion_method": "unknown"},
+        {"fusion_method": "rrf", "rrf_k": -1},
+        {"fusion_method": "rrf", "rrf_k": float("inf")},
+        {"fusion_method": "rrf", "rrf_k": True},
+        {"fusion_method": "rrf", "fusion_weights": {}},
+        {
+            "fusion_method": "rrf",
+            "fusion_weights": {"segmenter": 1.0, "reranker": -1.0},
+        },
+        {
+            "fusion_method": "rrf",
+            "fusion_weights": {"segmenter": 0.0, "reranker": 0.0},
+        },
+    ],
+)
+def test_segment_hashtags_rejects_invalid_fusion_before_model_loading(options):
+    """Verify malformed fusion options fail before the lazy model boundary."""
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError):
+            segment_hashtags(
+                ["#abc"],
+                ranking_strategy="ensemble",
+                **options,
+            )
+
+    get_model.assert_not_called()
+
+
+def test_rrf_requires_an_ensemble_capable_configuration_before_model_loading():
+    """Verify RRF cannot be labeled as active when no ensemble will run."""
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(
+            ValueError,
+            match="fusion_method=rrf requires ranking_strategy=ensemble",
+        ):
+            segment_hashtags(["#abc"], fusion_method="rrf")
+
+    get_model.assert_not_called()
 
 
 def test_auto_strategy_uses_reranker_only_when_configured():
@@ -629,6 +760,7 @@ def test_hashtag_file_job_resumes_deduplicates_and_returns_only_summary(tmp_path
         "reranker_model": None,
         "reranker_revision": None,
         "ranking_strategy": "segmenter",
+        "fusion_method": "top2",
     }
     assert [call.args[1] for call in pipeline.call_args_list] == [
         ["#icecold", "#benfica"],
@@ -659,6 +791,122 @@ def test_hashtag_file_job_resumes_deduplicates_and_returns_only_summary(tmp_path
         repeated = asyncio.run(continue_hashtag_file_job(summary["job_path"]))
     assert repeated["status"] == "completed"
     assert repeated["processed_this_call"] == 0
+    get_model.assert_not_called()
+
+
+@requires_secure_file_jobs
+def test_rrf_file_job_persists_and_restores_fusion_contract(tmp_path):
+    """Verify an interrupted RRF job resumes with identical weighted results."""
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#abc\n#xyz\n", encoding="utf-8")
+    configure_server(
+        ServerConfig(
+            reranker_model="custom/bert",
+            file_roots=(str(tmp_path),),
+        )
+    )
+
+    started = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="ensemble",
+        fusion_method="rrf",
+        rrf_k=0,
+        fusion_weights={"segmenter": 1, "reranker": 2},
+        max_candidates=3,
+        include_component_rankings=True,
+    )
+
+    assert started["fusion_method"] == "rrf"
+    with sqlite3.connect(started["job_path"]) as connection:
+        serialized = connection.execute(
+            "SELECT value FROM metadata WHERE key = 'run_options'"
+        ).fetchone()[0]
+    persisted = json.loads(serialized)
+    assert persisted["fusion_method"] == "rrf"
+    assert persisted["rrf_k"] == 0.0
+    assert persisted["fusion_weights"] == {"segmenter": 1.0, "reranker": 2.0}
+
+    with patch(
+        "hashformers.mcp_server.get_segmenter",
+        return_value=_rrf_segmenter(),
+    ):
+        interrupted = asyncio.run(
+            continue_hashtag_file_job(
+                started["job_path"],
+                max_unique_hashtags=1,
+            )
+        )
+    assert interrupted["status"] == "in_progress"
+    assert interrupted["fusion_method"] == "rrf"
+
+    with patch(
+        "hashformers.mcp_server.get_segmenter",
+        return_value=_rrf_segmenter(),
+    ):
+        completed = asyncio.run(
+            continue_hashtag_file_job(
+                started["job_path"],
+                max_unique_hashtags=1,
+            )
+        )
+
+    assert completed["status"] == "completed"
+    assert completed["fusion_method"] == "rrf"
+    records = [
+        json.loads(line)
+        for line in Path(completed["output_path"])
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert [record["selected_segmentation"] for record in records] == [
+        "ab c",
+        "xy z",
+    ]
+    assert all(record["fusion_method"] == "rrf" for record in records)
+    assert all(record["candidates"][0]["score"] < 0 for record in records)
+    assert all(
+        record["component_rankings"]["ensemble"] == record["candidates"]
+        for record in records
+    )
+
+
+@requires_secure_file_jobs
+def test_file_job_rejects_tampered_rrf_configuration_before_model_loading(
+    tmp_path,
+):
+    """Verify checkpoint edits cannot make RRF silently use default options."""
+    input_path = tmp_path / "hashtags.txt"
+    input_path.write_text("#abc\n", encoding="utf-8")
+    configure_server(
+        ServerConfig(
+            reranker_model="custom/bert",
+            file_roots=(str(tmp_path),),
+        )
+    )
+    started = start_hashtag_file_job(
+        str(input_path),
+        ranking_strategy="ensemble",
+        fusion_method="rrf",
+        fusion_weights={"segmenter": 1.0, "reranker": 2.0},
+    )
+    with sqlite3.connect(started["job_path"]) as connection:
+        serialized = connection.execute(
+            "SELECT value FROM metadata WHERE key = 'run_options'"
+        ).fetchone()[0]
+        run_options = json.loads(serialized)
+        del run_options["fusion_weights"]
+        connection.execute(
+            "UPDATE metadata SET value = ? WHERE key = 'run_options'",
+            (json.dumps(run_options, sort_keys=True),),
+        )
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(
+            ValueError,
+            match="job checkpoint contains invalid run options",
+        ):
+            asyncio.run(continue_hashtag_file_job(started["job_path"]))
+
     get_model.assert_not_called()
 
 
@@ -1537,6 +1785,82 @@ def test_rank_candidates_selects_precomputed_scores_without_loading_model():
     get_model.assert_not_called()
 
 
+def test_rank_candidates_uses_default_and_custom_rrf_options():
+    """Verify MCP candidate fusion exposes equal defaults and weighted RRF."""
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+    candidate_sets = [
+        {
+            "input": "abc",
+            "candidates": [
+                {"segmentation": "abc", "score": 1.0},
+                {"segmentation": "a bc", "score": 2.0},
+                {"segmentation": "ab c", "score": 3.0},
+            ],
+        }
+    ]
+
+    with patch(
+        "hashformers.mcp_server.get_segmenter",
+        return_value=_rrf_segmenter(),
+    ):
+        defaults = rank_candidates(
+            candidate_sets,
+            ranking_strategy="ensemble",
+            fusion_method="rrf",
+            max_candidates=3,
+        )
+        explicit_defaults = rank_candidates(
+            candidate_sets,
+            ranking_strategy="ensemble",
+            fusion_method="rrf",
+            rrf_k=60,
+            fusion_weights={"segmenter": 1.0, "reranker": 1.0},
+            max_candidates=3,
+        )
+        weighted = rank_candidates(
+            candidate_sets,
+            ranking_strategy="ensemble",
+            fusion_method="rrf",
+            rrf_k=0,
+            fusion_weights={"segmenter": 1.0, "reranker": 2.0},
+            max_candidates=3,
+            include_component_rankings=True,
+        )
+
+    assert defaults["results"] == explicit_defaults["results"]
+    assert defaults["results"][0]["selected_segmentation"] == "abc"
+    item = weighted["results"][0]
+    assert item["selected_segmentation"] == "ab c"
+    assert item["fusion_method"] == "rrf"
+    assert [candidate["score"] for candidate in item["candidates"]] == (
+        pytest.approx([-7 / 3, -2.0, -7 / 6])
+    )
+    assert [
+        candidate["segmentation"]
+        for candidate in item["component_rankings"]["segmenter"]
+    ] == ["abc", "a bc", "ab c"]
+    assert [
+        candidate["segmentation"]
+        for candidate in item["component_rankings"]["reranker"]
+    ] == ["ab c", "abc", "a bc"]
+
+
+def test_rank_candidates_rejects_invalid_rrf_before_model_loading():
+    """Verify candidate RRF validation does not cross the lazy model boundary."""
+    configure_server(ServerConfig(reranker_model="custom/bert"))
+
+    with patch("hashformers.mcp_server.get_segmenter") as get_model:
+        with pytest.raises(ValueError, match="fusion_weights"):
+            rank_candidates(
+                [{"input": "abc", "candidates": []}],
+                ranking_strategy="ensemble",
+                fusion_method="rrf",
+                fusion_weights={"segmenter": 1.0},
+            )
+
+    get_model.assert_not_called()
+
+
 def test_rank_candidates_preserves_selected_tie_order():
     """Verify serialized ties match ProbabilityDictionary selection order."""
     candidate_sets = [
@@ -1898,6 +2222,20 @@ def test_mcp_server_exposes_complete_structured_surface():
     assert hashtag_schema["steps"]["default"] == 5
     assert hashtag_schema["max_candidates"]["default"] == 5
     assert hashtag_schema["ranking_strategy"]["default"] == "auto"
+    for tool_name in (
+        "segment_hashtags",
+        "start_hashtag_file_job",
+        "rank_candidates",
+    ):
+        schema = tools_by_name[tool_name].input_schema["properties"]
+        assert schema["fusion_method"]["default"] == "top2"
+        assert schema["fusion_method"]["enum"] == ["top2", "rrf"]
+        assert schema["rrf_k"]["default"] == 60
+        assert schema["fusion_weights"]["default"] is None
+        assert {variant["type"] for variant in schema["fusion_weights"]["anyOf"]} == {
+            "object",
+            "null",
+        }
     file_schema = tools_by_name["continue_hashtag_file_job"].input_schema["properties"]
     assert "context" not in file_schema
     sample_schema = tools_by_name["sample_hashtag_file"].input_schema["properties"]

--- a/tests/test_rrf_fusion.py
+++ b/tests/test_rrf_fusion.py
@@ -7,6 +7,25 @@ from hashformers.ensemble.rrf_fusion import (
     ReciprocalRankFusionEnsembler,
     reciprocal_rank_fusion,
 )
+from hashformers.segmenter import BaseWordSegmenter
+
+
+class _FixedSegmenter:
+    def run(self, _word_list, **_kwargs):
+        return ProbabilityDictionary({"abc": 1.0, "a bc": 2.0, "ab c": 3.0})
+
+
+class _FixedReranker:
+    def rerank(self, _segmenter_run, **_kwargs):
+        return ProbabilityDictionary({"ab c": 1.0, "abc": 2.0, "a bc": 3.0})
+
+
+def _model_free_segmenter(ensembler):
+    return BaseWordSegmenter(
+        segmenter=_FixedSegmenter(),
+        reranker=_FixedReranker(),
+        ensembler=ensembler,
+    )
 
 
 def test_known_rrf_scores_and_full_list_order():
@@ -32,6 +51,79 @@ def test_rrf_can_select_candidate_outside_segmenter_top_two():
     )
 
     assert next(iter(result.get_top_k(k=1))) == "ab c"
+
+
+def test_base_segmenter_runs_weighted_rrf_and_exposes_every_ranking():
+    segmenter = _model_free_segmenter(ensembler=object())
+
+    output = segmenter.segment(
+        ["abc"],
+        fusion_method="rrf",
+        ensembler_kwargs={
+            "rrf_k": 0,
+            "fusion_weights": {"segmenter": 1.0, "reranker": 2.0},
+        },
+        return_ranks=True,
+    )
+
+    assert output.output == ["ab c"]
+    assert output.fusion_method == "rrf"
+    assert output.segmenter_rank["segmentation"].tolist() == [
+        "abc",
+        "a bc",
+        "ab c",
+    ]
+    assert output.reranker_rank["segmentation"].tolist() == [
+        "ab c",
+        "abc",
+        "a bc",
+    ]
+    assert output.ensemble_rank["segmentation"].tolist() == [
+        "ab c",
+        "abc",
+        "a bc",
+    ]
+    assert output.ensemble_rank["score"].tolist() == pytest.approx(
+        [-7 / 3, -2.0, -7 / 6]
+    )
+
+
+def test_base_segmenter_preserves_top2_fusion_contract():
+    class RecordingTop2:
+        def __init__(self):
+            self.call = None
+
+        def run(self, segmenter_run, reranker_run, **kwargs):
+            self.call = (segmenter_run, reranker_run, kwargs)
+            return ProbabilityDictionary({"a bc": 0.0, "abc": 1.0})
+
+    top2 = RecordingTop2()
+    segmenter = _model_free_segmenter(ensembler=top2)
+
+    output = segmenter.segment(
+        ["abc"],
+        fusion_method="top2",
+        ensembler_kwargs={"alpha": 0.4, "beta": 0.6},
+        return_ranks=True,
+    )
+
+    assert output.output == ["a bc"]
+    assert output.fusion_method == "top2"
+    assert top2.call[2] == {"alpha": 0.4, "beta": 0.6}
+
+
+def test_rrf_requires_an_active_reranker_and_ensembler_before_segmentation():
+    class UnusedSegmenter:
+        def run(self, _word_list, **_kwargs):
+            raise AssertionError("segmenter should not run")
+
+    segmenter = BaseWordSegmenter(segmenter=UnusedSegmenter())
+
+    with pytest.raises(
+        ValueError,
+        match="fusion_method=rrf requires an active reranker and ensembler",
+    ):
+        segmenter.segment(["abc"], fusion_method="rrf")
 
 
 def test_rrf_depends_on_rank_not_score_magnitude():


### PR DESCRIPTION
## Summary

- enforce that RRF only runs with an active reranker and ensemble selection
- expose and validate RRF options consistently across interactive segmentation, candidate ranking, and resumable file jobs
- persist normalized RRF settings and reject invalid or tampered checkpoint configuration
- add model-free library, MCP, schema, validation, and resume regression coverage
- document the RRF formula, defaults, tie handling, score direction, and usage in the README and agent skill

## Root cause

The RRF scoring implementation worked, but its surrounding integration contract was incomplete. MCP responses and tests still had stale fusion assumptions, non-ensemble requests could report RRF even though no fusion ran, and resumed file jobs did not validate the complete persisted fusion configuration.

## Impact

RRF now has deterministic end-to-end coverage, explicit failure behavior for unsupported configurations, reproducible resumable jobs, and discoverable MCP schemas while preserving `top2` as the default.

## Validation

- `PYTHONPATH=src .venv-mcp/bin/python -m pytest tests/test_rrf_fusion.py -q` — 13 passed
- `PYTHONPATH=src .venv-mcp/bin/python -m pytest tests/test_mcp_server.py -q` — 84 passed
- `git diff --check`

Closes #90